### PR TITLE
Correct the actual user for sudo agent image

### DIFF
--- a/configs/linux/Agent/Ubuntu/Ubuntu-sudo.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu-sudo.Dockerfile
@@ -8,7 +8,7 @@
 # Weight 1
 
 ## ${agentCommentHeader}
-## This image allows to do *__sudo__* without a password for the *__builduser__* user. 
+## This image allows to do *__sudo__* without a password for the *__buildagent__* user. 
 
 # Based on ${teamcityAgentImage}
 FROM ${teamcityAgentImage}


### PR DESCRIPTION
`buildagent` is the default user and the user with `sudo` access in the `sudo` flavored Docker containers.