### PR TITLE
[Hotifx] Fix teamcity-server installation on Ubuntu 18.04

### DIFF
--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -39,6 +39,7 @@ RUN set -eux; \
     mkdir -p /opt/java/openjdk; \
     cd /opt/java/openjdk; \
     tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    chown -R root:root /opt/java; \
     rm -rf /tmp/openjdk.tar.gz;
 
 ENV JAVA_HOME=/opt/java/openjdk \

--- a/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -35,6 +35,7 @@ RUN set -eux; \
     mkdir -p /opt/java/openjdk; \
     cd /opt/java/openjdk; \
     tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    chown -R root:root /opt/java; \
     rm -rf /tmp/openjdk.tar.gz;
 
 ENV JAVA_HOME=/opt/java/openjdk \


### PR DESCRIPTION
I have changed jdk files owner's uid to root, to fix:

```
failed to register layer: ApplyLayer exit status 1 stdout:  stderr: Container ID 3175151 cannot be mapped to a host ID
```
error, which I faced on Ubuntu 18.04 when I have trying to install TeamCity 2020.2.x. Previous versions (2019.x & 2020.1.x) installed ok on my PC.
There is also an [issue about it.](https://github.com/JetBrains/teamcity-docker-server/issues/39)