### PR TITLE
Use ASP.NET Core runtime instead of .NET Core

### DIFF
--- a/configs/linux.config
+++ b/configs/linux.config
@@ -18,14 +18,14 @@ dotnetLinuxComponentName=${dotnetComponentName} Checksum (SHA512) ${dotnetLinuxC
 
 # https://dotnet.microsoft.com/download/dotnet/3.1
 dotnetLinuxComponentVersion_31=${dotnetComponentVersion_31}
-dotnetLinuxComponent_31=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/Runtime/${dotnetComponentVersion_31}/dotnet-runtime-${dotnetComponentVersion_31}-linux-x64.tar.gz
-dotnetLinuxComponentSHA512_31=cc4b2fef46e94df88bf0fc11cb15439e79bd48da524561dffde80d3cd6db218133468ad2f6785803cf0c13f000d95ff71eb258cec76dd8eb809676ec1cb38fac
+dotnetLinuxComponent_31=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${dotnetComponentVersion_31}/aspnetcore-runtime-${dotnetComponentVersion_31}-linux-x64.tar.gz
+dotnetLinuxComponentSHA512_31=f59252166dbfe11a78373226222d6a34484b9132e24283222aea8a950a5e9657da2e4d4e9ff8cbcc2fd7c7705e13bf42a31232a6012d1e247efc718e3d8e2df1
 dotnetLinuxComponentName_31=${dotnetComponentName_31} Checksum (SHA512) ${dotnetLinuxComponentSHA512_31}
 
 # https://dotnet.microsoft.com/download/dotnet/5.0
 dotnetLinuxComponentVersion_50=${dotnetComponentVersion_50}
-dotnetLinuxComponent_50=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/Runtime/${dotnetComponentVersion_50}/dotnet-runtime-${dotnetComponentVersion_50}-linux-x64.tar.gz
-dotnetLinuxComponentSHA512_50=32b5f86db3b1d4c21e3cf616d22f0e4a7374385dac0cf03cdebf3520dcf846460d9677ec1829a180920740a0237d64f6eaa2421d036a67f4fe9fb15d4f6b1db9
+dotnetLinuxComponent_50=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${dotnetComponentVersion_50}/aspnetcore-runtime-${dotnetComponentVersion_50}-linux-x64.tar.gz
+dotnetLinuxComponentSHA512_50=0529f23ffa651ac2c2807b70d6e5034f6ae4c88204afdaaa76965ef604d6533f9440d68d9f2cdd3a9f2ca37e9140e6c61a9f9207d430c71140094c7d5c33bf79
 dotnetLinuxComponentName_50=${dotnetComponentName_50} Checksum (SHA512) ${dotnetLinuxComponentSHA512_50}
 
 # https://packages.ubuntu.com/focal/git

--- a/configs/windows.config
+++ b/configs/windows.config
@@ -23,14 +23,14 @@ dotnetWindowsComponentName=${dotnetComponentName} Checksum (SHA512) ${dotnetWind
 
 # https://dotnet.microsoft.com/download/dotnet/3.1
 dotnetWindowsComponentVersion_31=${dotnetComponentVersion_31}
-dotnetWindowsComponent_31=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/Runtime/${dotnetComponentVersion_31}/dotnet-runtime-${dotnetComponentVersion_31}-win-x64.zip
-dotnetWindowsComponentSHA512_31=7ba766b2f388ab09beee6a465f1eeb6b9a6858c8b6da51dacc79622b110558ef6211a40e715a16b526f2da08216c99143570b8253ff2c5ad874400475d1feb44
+dotnetWindowsComponent_31=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${dotnetComponentVersion_31}/aspnetcore-runtime-${dotnetComponentVersion_31}-win-x64.zip
+dotnetWindowsComponentSHA512_31=b31ecee90ace55264c2f730a73f48b6bbbc1a3e2c58cd2f424411f3728fddcf28babd008a597be732bd9d5ccc105d64d9ecb61d5a4c6d18fa795f3bb8632ef67
 dotnetWindowsComponentName_31=${dotnetComponentName_31} Checksum (SHA512) ${dotnetWindowsComponentSHA512_31}
 
 # https://dotnet.microsoft.com/download/dotnet/5.0
 dotnetWindowsComponentVersion_50=${dotnetComponentVersion_50}
-dotnetWindowsComponent_50=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/Runtime/${dotnetComponentVersion_50}/dotnet-runtime-${dotnetComponentVersion_50}-win-x64.zip
-dotnetWindowsComponentSHA512_50=636f22bfbfd98c80c96f2fc3815beb42ee2699cf2a410eeba24ddcc9304bc39594260eca4061b012d4b02b9c4592fa6927343077df053343a9c344a9289658e1
+dotnetWindowsComponent_50=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${dotnetComponentVersion_50}/aspnetcore-runtime-${dotnetComponentVersion_50}-win-x64.zip
+dotnetWindowsComponentSHA512_50=c6b9938f029e4425ced6d9dd0612cfb0698045297eb257f0857bbf5b22481361fab3a19660e1063f41b6d13e9a367cb4d0d71fc23f84dd01c345b1f1aac647b8
 dotnetWindowsComponentName_50=${dotnetComponentName_50} Checksum (SHA512) ${dotnetWindowsComponentSHA512_50}
 
 mercurialWindowsComponentName=Mercurial x64 v.5.9.1


### PR DESCRIPTION
The PR replaces .NET Core runtime with ASP.NET Core for versions 3.1.x and 5.0.x.
Some projects like unit tests require ASP.NET Core runtime.

```
[14:30:44][dotnet test] Testhost process exited with error: It was not possible to find any compatible framework version
[14:30:44][dotnet test] The framework 'Microsoft.AspNetCore.App', version '3.1.0' (x64) was not found.
[14:30:44][dotnet test]   - The following frameworks were found:
[14:30:44][dotnet test]       6.0.0 at [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
```