### PR TITLE
Add Git LFS to Linux images

### DIFF
--- a/configs/linux.config
+++ b/configs/linux.config
@@ -32,6 +32,10 @@ dotnetLinuxComponentName_50=${dotnetComponentName_50} Checksum (SHA512) ${dotnet
 gitLinuxComponentVersion=1:2.25.1-1ubuntu3.2
 gitLinuxComponentName=Git v.2.25.1
 
+# https://packages.ubuntu.com/focal/git-lfs
+gitLFSLinuxComponentVersion=2.9.2-1
+gitLFSLinuxComponentName=Git LFS v.2.9.2
+
 dockerComposeLinuxComponentVersion=1.28.5
 dockerLinuxComponentVersion=5:20.10.12~3-0~ubuntu
 dockerLinuxComponentName=[Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12)

--- a/configs/linux.config
+++ b/configs/linux.config
@@ -40,5 +40,5 @@ containerdIoLinuxComponentName=[Containerd.io v1.4.12-1](https://ubuntu.pkgs.org
 containerdIoLinuxComponentVersion=1.4.12-1
 
 # https://www.perforce.com/perforce-packages
-p4Version=2021.2-2220431
-p4Name=Perforce Helix Core client (p4) [2021.2-2220431](https://www.perforce.com/products/helix-core)
+p4Version=2021.2-2250781
+p4Name=Perforce Helix Core client (p4) [2021.2-2250781](https://www.perforce.com/products/helix-core)

--- a/configs/linux/Agent/Ubuntu/18.04/Ubuntu.Dockerfile.config
+++ b/configs/linux/Agent/Ubuntu/18.04/Ubuntu.Dockerfile.config
@@ -6,3 +6,7 @@ dotnetLibs=libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g
 # https://packages.ubuntu.com/bionic/git
 gitLinuxComponentVersion=1:2.17.1-1ubuntu0.9
 gitLinuxComponentName=Git v.2.17.1
+
+# https://packages.ubuntu.com/bionic/git-lfs
+gitLFSLinuxComponentVersion=2.3.4-1
+gitLFSLinuxComponentName=Git LFS v.2.3.4

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -8,6 +8,7 @@
 # ARG teamcityMinimalAgentImage
 # ARG dotnetLibs
 # ARG gitLinuxComponentVersion
+# ARG gitLFSLinuxComponentVersion
 # ARG dockerComposeLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
 
@@ -53,6 +54,7 @@ ARG dotnetLinuxComponent_50
 ARG dotnetLinuxComponentSHA512_50
 ARG dotnetLibs
 ARG gitLinuxComponentVersion
+ARG gitLFSLinuxComponentVersion
 ARG dockerComposeLinuxComponentVersion
 ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
@@ -61,7 +63,8 @@ ARG p4Version
 RUN apt-get update && \
 # Install ${gitLinuxComponentName}
 # Install Mercurial
-    apt-get install -y git=${gitLinuxComponentVersion} mercurial apt-transport-https software-properties-common && \
+    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} mercurial apt-transport-https software-properties-common && \
+    git lfs install --system && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
 # Install ${p4Name}

--- a/configs/linux/Server/Ubuntu/18.04/Ubuntu.Dockerfile.config
+++ b/configs/linux/Server/Ubuntu/18.04/Ubuntu.Dockerfile.config
@@ -6,3 +6,7 @@ ubuntuImage=ubuntu:18.04
 # https://packages.ubuntu.com/bionic/git
 gitLinuxComponentVersion=1:2.17.1-1ubuntu0.9
 gitLinuxComponentName=Git v.2.17.1
+
+# https://packages.ubuntu.com/bionic/git-lfs
+gitLFSLinuxComponentVersion=2.3.4-1
+gitLFSLinuxComponentName=Git LFS v.2.3.4

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -3,6 +3,7 @@
 # ARG jdkServerLinuxComponentMD5SUM
 # ARG ubuntuImage
 # ARG gitLinuxComponentVersion
+# ARG gitLFSLinuxComponentVersion
 
 # Id teamcity-server
 # Tag ${versionTag}-linux${linuxVersion}
@@ -62,11 +63,15 @@ EXPOSE 8111
 # Install ${gitLinuxComponentName}
 ARG gitLinuxComponentVersion
 
+# Install ${gitLFSLinuxComponentName}
+ARG gitLFSLinuxComponentVersion
+
 # Install ${p4Name}
 ARG p4Version
 
 RUN apt-get update && \
-    apt-get install -y git=${gitLinuxComponentVersion} mercurial gnupg && \
+    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} mercurial gnupg && \
+    git lfs install --system && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/configs/linux/Server/UbuntuARM/18.04/UbuntuARM.Dockerfile.config
+++ b/configs/linux/Server/UbuntuARM/18.04/UbuntuARM.Dockerfile.config
@@ -6,3 +6,7 @@ ubuntuImage=ubuntu:18.04
 # https://packages.ubuntu.com/bionic/git
 gitLinuxComponentVersion=1:2.17.1-1ubuntu0.9
 gitLinuxComponentName=Git v.2.17.1
+
+# https://packages.ubuntu.com/bionic/git-lfs
+gitLFSLinuxComponentVersion=2.3.4-1
+gitLFSLinuxComponentName=Git LFS v.2.3.4

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -3,6 +3,7 @@
 # ARG jdkServerLinuxARM64ComponentMD5SUM
 # ARG ubuntuImage
 # ARG gitLinuxComponentVersion
+# ARG gitLFSLinuxComponentVersion
 
 # Id teamcity-server
 # Tag ${versionTag}-linux${linuxVersion}
@@ -62,8 +63,12 @@ EXPOSE 8111
 # Install ${gitLinuxComponentName}
 ARG gitLinuxComponentVersion
 
+# Install ${gitLFSLinuxComponentName}
+ARG gitLFSLinuxComponentVersion
+
 RUN apt-get update && \
-    apt-get install -y git=${gitLinuxComponentVersion} mercurial && \
+    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} mercurial && \
+    git lfs install --system && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hello! While trying out TeamCity with the Docker images I encountered that Git LFS is not installed automatically, so I had trouble trying out a Pipeline that requires it.

This PR simply installs the `git-lfs` package, available on both 20.04 and 18.04, and afterwards `git lfs install --system` is called.

I didn't upload the generated Dockerfiles because I wasn't able to properly make the end lines work with Git in those files.

I've also needed to update the p4 versions, otherwise the images were not building.