### PR TITLE
TW-68887/better arm support

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -7,10 +7,10 @@ powerShellComponentName=[PowerShell](https://github.com/PowerShell/PowerShell#ge
 
 # Please update checksum(SHA512) in windows.config and linux.config after version change
 dotnetComponentVersion=6.0.100
-dotnetComponentName=.NET SDK x64 v.${dotnetComponentVersion}
+dotnetComponentName=.NET SDK v.${dotnetComponentVersion}
 
 dotnetComponentVersion_31=3.1.21
-dotnetComponentName_31=.NET Runtime x64 v.${dotnetComponentVersion_31}
+dotnetComponentName_31=.NET Runtime v.${dotnetComponentVersion_31}
 
 dotnetComponentVersion_50=5.0.12
-dotnetComponentName_50=.NET Runtime x64 v.${dotnetComponentVersion_50}
+dotnetComponentName_50=.NET Runtime v.${dotnetComponentVersion_50}

--- a/configs/linux.config
+++ b/configs/linux.config
@@ -14,19 +14,19 @@ jdkServerLinuxComponentName=JDK <img align="center" height="18" src="/logo/corre
 dotnetLinuxComponentVersion=${dotnetComponentVersion}
 dotnetLinuxComponent=https://${proxyUrl}dotnetcli.blob.core.windows.net/dotnet/Sdk/${dotnetComponentVersion}/dotnet-sdk-${dotnetComponentVersion}-linux-x64.tar.gz
 dotnetLinuxComponentSHA512=cb0d174a79d6294c302261b645dba6a479da8f7cf6c1fe15ae6998bc09c5e0baec810822f9e0104e84b0efd51fdc0333306cb2a0a6fcdbaf515a8ad8cf1af25b
-dotnetLinuxComponentName=${dotnetComponentName} Checksum (SHA512) ${dotnetLinuxComponentSHA512}
+dotnetLinuxComponentName=${dotnetComponentName} x86 Checksum (SHA512) ${dotnetLinuxComponentSHA512}
 
 # https://dotnet.microsoft.com/download/dotnet/3.1
 dotnetLinuxComponentVersion_31=${dotnetComponentVersion_31}
 dotnetLinuxComponent_31=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/Runtime/${dotnetComponentVersion_31}/dotnet-runtime-${dotnetComponentVersion_31}-linux-x64.tar.gz
 dotnetLinuxComponentSHA512_31=cc4b2fef46e94df88bf0fc11cb15439e79bd48da524561dffde80d3cd6db218133468ad2f6785803cf0c13f000d95ff71eb258cec76dd8eb809676ec1cb38fac
-dotnetLinuxComponentName_31=${dotnetComponentName_31} Checksum (SHA512) ${dotnetLinuxComponentSHA512_31}
+dotnetLinuxComponentName_31=${dotnetComponentName_31} x86 Checksum (SHA512) ${dotnetLinuxComponentSHA512_31}
 
 # https://dotnet.microsoft.com/download/dotnet/5.0
 dotnetLinuxComponentVersion_50=${dotnetComponentVersion_50}
 dotnetLinuxComponent_50=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/Runtime/${dotnetComponentVersion_50}/dotnet-runtime-${dotnetComponentVersion_50}-linux-x64.tar.gz
 dotnetLinuxComponentSHA512_50=32b5f86db3b1d4c21e3cf616d22f0e4a7374385dac0cf03cdebf3520dcf846460d9677ec1829a180920740a0237d64f6eaa2421d036a67f4fe9fb15d4f6b1db9
-dotnetLinuxComponentName_50=${dotnetComponentName_50} Checksum (SHA512) ${dotnetLinuxComponentSHA512_50}
+dotnetLinuxComponentName_50=${dotnetComponentName_50} x86 Checksum (SHA512) ${dotnetLinuxComponentSHA512_50}
 
 # https://packages.ubuntu.com/focal/git
 # http://ppa.launchpad.net/git-core/ppa/ubuntu/dists/focal/main/binary-amd64/

--- a/configs/linux/Agent/UbuntuARM/18.04-sudo/UbuntuARM-sudo.Dockerfile.config
+++ b/configs/linux/Agent/UbuntuARM/18.04-sudo/UbuntuARM-sudo.Dockerfile.config
@@ -1,0 +1,3 @@
+linuxVersion=-arm64-18.04
+repo=
+teamcityAgentImage=teamcity-agent:${versionTag}-linux${linuxVersion}

--- a/configs/linux/Agent/UbuntuARM/18.04/UbuntuARM.Dockerfile.config
+++ b/configs/linux/Agent/UbuntuARM/18.04/UbuntuARM.Dockerfile.config
@@ -1,0 +1,13 @@
+linuxVersion=-arm64-18.04
+repo=
+teamcityMinimalAgentImage=teamcity-minimal-agent:${versionTag}-linux${linuxVersion}
+dotnetLibs=libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g
+
+# https://packages.ubuntu.com/bionic/git
+# http://ppa.launchpad.net/git-core/ppa/ubuntu/dists/bionic/main/binary-arm64/
+gitLinuxComponentVersion=1:2.36.0-0ppa1~ubuntu18.04.1
+gitLinuxComponentName=Git v.2.36.0
+
+# https://packages.ubuntu.com/bionic/git-lfs
+gitLFSLinuxComponentVersion=2.3.4-1
+gitLFSLinuxComponentName=Git LFS v.2.3.4

--- a/configs/linux/Agent/UbuntuARM/20.04-sudo/UbuntuARM-sudo.Dockerfile.config
+++ b/configs/linux/Agent/UbuntuARM/20.04-sudo/UbuntuARM-sudo.Dockerfile.config
@@ -1,0 +1,3 @@
+linuxVersion=-arm64
+repo=https://hub.docker.com/r/jetbrains/
+teamcityAgentImage=teamcity-agent:${versionTag}-linux${linuxVersion}

--- a/configs/linux/Agent/UbuntuARM/20.04/UbuntuARM.Dockerfile.config
+++ b/configs/linux/Agent/UbuntuARM/20.04/UbuntuARM.Dockerfile.config
@@ -1,0 +1,4 @@
+linuxVersion=-arm64
+repo=https://hub.docker.com/r/jetbrains/
+teamcityMinimalAgentImage=teamcity-minimal-agent:${versionTag}-linux${linuxVersion}
+dotnetLibs=libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM-sudo.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM-sudo.Dockerfile
@@ -1,0 +1,25 @@
+# The list of required arguments
+# ARG teamcityAgentImage
+
+# Id teamcity-agent
+# Tag ${versionTag}-linux${linuxVersion}-sudo
+# Platform ${linuxPlatform}
+# Repo ${repo}
+# Weight 1
+
+## ${agentCommentHeader}
+## This image allows to do *__sudo__* without a password for the *__buildagent__* user. ## To enable Docker, please add the following arguments: ```--privileged -e DOCKER_IN_DOCKER=start```.
+
+# Based on ${teamcityAgentImage}
+FROM ${teamcityAgentImage}
+
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends sudo && \
+    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    echo 'buildagent ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \  
+    rm -rf /var/lib/apt/lists/*
+
+USER buildagent

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM-sudo.Dockerignore
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM-sudo.Dockerignore
@@ -1,0 +1,1 @@
+TeamCity

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -1,0 +1,121 @@
+# The list of required arguments
+# ARG dotnetLinuxARM64Component
+# ARG dotnetLinuxARM64ComponentSHA512
+# ARG dotnetLinuxARM64Component_31
+# ARG dotnetLinuxARM64ComponentSHA512_31
+# ARG dotnetLinuxARM64Component_50
+# ARG dotnetLinuxARM64ComponentSHA512_50
+# ARG teamcityMinimalAgentImage
+# ARG dotnetLibs
+# ARG gitLinuxComponentVersion
+# ARG gitLFSLinuxComponentVersion
+# ARG dockerComposeLinuxComponentVersion
+# ARG dockerLinuxComponentVersion
+
+# Id teamcity-agent
+# Platform ${linuxPlatform}
+# Tag ${versionTag}-linux${linuxVersion}
+# Tag ${latestTag}
+# Tag ${versionTag}
+# Repo ${repo}
+# Weight 1
+
+## ${agentCommentHeader}
+
+# Based on ${teamcityMinimalAgentImage}
+FROM ${teamcityMinimalAgentImage}
+
+USER root
+
+COPY run-docker.sh /services/run-docker.sh
+
+ARG dotnetCoreLinuxComponentVersion
+
+    # Opt out of the telemetry feature
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \
+    # Disable first time experience
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    # Configure Kestrel web server to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
+    NUGET_XMLDOC_MODE=skip \
+    GIT_SSH_VARIANT=ssh \
+    DOTNET_SDK_VERSION=${dotnetCoreLinuxComponentVersion}
+
+ARG dotnetLinuxARM64Component
+ARG dotnetLinuxARM64ComponentSHA512
+ARG dotnetLinuxARM64Component_31
+ARG dotnetLinuxARM64ComponentSHA512_31
+ARG dotnetLinuxARM64Component_50
+ARG dotnetLinuxARM64ComponentSHA512_50
+ARG dotnetLibs
+ARG gitLinuxComponentVersion
+ARG gitLFSLinuxComponentVersion
+ARG dockerComposeLinuxComponentVersion
+ARG dockerLinuxComponentVersion
+ARG containerdIoLinuxComponentVersion
+
+RUN apt-get update && \
+# Install ${gitLinuxComponentName}
+# Install ${gitLFSLinuxComponentName}
+# Install Mercurial
+    apt-get install -y mercurial apt-transport-https software-properties-common && \
+    add-apt-repository ppa:git-core/ppa -y && \
+    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
+    git lfs install --system && \
+    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+# Install ${dockerLinuxComponentName}, ${containerdIoLinuxComponentName}
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    apt-cache policy docker-ce && \
+    apt-get update && \
+    apt-get install -y  docker-ce=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
+    docker-ce-cli=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
+    containerd.io:arm64=${containerdIoLinuxComponentVersion} \
+    systemd && \
+    systemctl disable docker && \
+    sed -i -e 's/\r$//' /services/run-docker.sh && \
+# Install [Docker Compose v.${dockerComposeLinuxComponentVersion}](https://github.com/docker/compose/releases/tag/${dockerComposeLinuxComponentVersion})
+    curl -SL "https://github.com/docker/compose/releases/download/${dockerComposeLinuxComponentVersion}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && \
+# Dotnet
+    apt-get install -y --no-install-recommends ${dotnetLibs} && \
+    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /usr/share/dotnet && \
+# Install [${dotnetLinuxARM64ComponentName_31}](${dotnetLinuxARM64Component_31})
+    curl -SL ${dotnetLinuxARM64Component_31} --output /tmp/dotnet.tar.gz && \
+    echo "${dotnetLinuxARM64ComponentSHA512_31} */tmp/dotnet.tar.gz" | sha512sum -c -; \
+    tar -zxf /tmp/dotnet.tar.gz -C /usr/share/dotnet && \
+    rm /tmp/dotnet.tar.gz && \
+    find /usr/share/dotnet -name "*.lzma" -type f -delete && \
+# Install [${dotnetLinuxARM64ComponentName_50}](${dotnetLinuxARM64Component_50})
+    curl -SL ${dotnetLinuxARM64Component_50} --output /tmp/dotnet.tar.gz && \
+    echo "${dotnetLinuxARM64ComponentSHA512_50} */tmp/dotnet.tar.gz" | sha512sum -c -; \
+    tar -zxf /tmp/dotnet.tar.gz -C /usr/share/dotnet && \
+    rm /tmp/dotnet.tar.gz && \
+    find /usr/share/dotnet -name "*.lzma" -type f -delete && \
+# Install [${dotnetLinuxARM64ComponentName}](${dotnetLinuxARM64Component})
+    curl -SL ${dotnetLinuxARM64Component} --output /tmp/dotnet.tar.gz && \
+    echo "${dotnetLinuxARM64ComponentSHA512} */tmp/dotnet.tar.gz" | sha512sum -c -; \
+    tar -zxf /tmp/dotnet.tar.gz -C /usr/share/dotnet && \
+    rm /tmp/dotnet.tar.gz && \
+    find /usr/share/dotnet -name "*.lzma" -type f -delete && \
+    ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet && \
+# Trigger .NET CLI first run experience by running arbitrary cmd to populate local package cache
+    dotnet help && \
+    dotnet --info && \
+# Other
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    chown -R buildagent:buildagent /services && \
+    usermod -aG docker buildagent
+
+# A better fix for TW-52939 Dockerfile build fails because of aufs
+VOLUME /var/lib/docker
+
+USER buildagent
+

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerignore
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerignore
@@ -1,0 +1,1 @@
+TeamCity

--- a/configs/linux/MinimalAgent/UbuntuARM/20.04/UbuntuARM.Dockerfile.config
+++ b/configs/linux/MinimalAgent/UbuntuARM/20.04/UbuntuARM.Dockerfile.config
@@ -1,4 +1,4 @@
-linuxVersion=-arm64-20.04
+linuxVersion=-arm64
 repo=
 # https://hub.docker.com/_/ubuntu/
 ubuntuImage=ubuntu:20.04

--- a/configs/linux/Server/UbuntuARM/20.04/UbuntuARM.Dockerfile.config
+++ b/configs/linux/Server/UbuntuARM/20.04/UbuntuARM.Dockerfile.config
@@ -1,4 +1,4 @@
-linuxVersion=-arm64-20.04
+linuxVersion=-arm64
 repo=
 # https://hub.docker.com/_/ubuntu/
 ubuntuImage=ubuntu:20.04

--- a/configs/linuxARM.config
+++ b/configs/linuxARM.config
@@ -1,7 +1,25 @@
-jdkLinuxARM64ComponentMD5SUM=b0b989af7b8635d0dd0724707206b67c
-jdkLinuxARM64Component=https://${proxyUrl}corretto.aws/downloads/resources/8.292.10.1/amazon-corretto-8.292.10.1-linux-aarch64.tar.gz
-jdkLinuxARM64ComponentName=JDK <img align="center" height="18" src="/logo/corretto.png"> Amazon Corretto aarch64 v.8.292.10.1 Checksum (MD5) ${jdkLinuxARM64ComponentMD5SUM}
+jdkLinuxARM64ComponentMD5SUM=9da32690c0b037569e6c622a6795ac80
+jdkLinuxARM64Component=https://${proxyUrl}corretto.aws/downloads/resources/11.0.15.9.1/amazon-corretto-11.0.15.9.1-linux-aarch64.tar.gz
+jdkLinuxARM64ComponentName=JDK <img align="center" height="18" src="/logo/corretto.png"> Amazon Corretto aarch64 v.11.0.15.9.1 Checksum (MD5) ${jdkLinuxARM64ComponentMD5SUM}
 
-jdkServerLinuxARM64ComponentMD5SUM=b0b989af7b8635d0dd0724707206b67c
-jdkServerLinuxARM64Component=https://${proxyUrl}corretto.aws/downloads/resources/8.292.10.1/amazon-corretto-8.292.10.1-linux-aarch64.tar.gz
-jdkServerLinuxARM64ComponentName=JDK <img align="center" height="18" src="/logo/corretto.png"> Amazon Corretto aarch64 v.8.292.10.1 Checksum (MD5) ${jdkServerLinuxARM64ComponentMD5SUM}
+jdkServerLinuxARM64ComponentMD5SUM=9da32690c0b037569e6c622a6795ac80
+jdkServerLinuxARM64Component=https://${proxyUrl}corretto.aws/downloads/resources/11.0.15.9.1/amazon-corretto-11.0.15.9.1-linux-aarch64.tar.gz
+jdkServerLinuxARM64ComponentName=JDK <img align="center" height="18" src="/logo/corretto.png"> Amazon Corretto aarch64 v.11.0.15.9.1 Checksum (MD5) ${jdkServerLinuxARM64ComponentMD5SUM}
+
+# https://dotnet.microsoft.com/download/dotnet/6.0
+dotnetLinuxARM64ComponentVersion=${dotnetComponentVersion}
+dotnetLinuxARM64Component=https://${proxyUrl}dotnetcli.blob.core.windows.net/dotnet/Sdk/${dotnetComponentVersion}/dotnet-sdk-${dotnetComponentVersion}-linux-arm64.tar.gz
+dotnetLinuxARM64ComponentSHA512=e5983c1c599d6dc7c3c7496b9698e47c68247f04a5d0d1e3162969d071471297bce1c2fd3a1f9fb88645006c327ae79f880dcbdd8eefc9166fd717331f2716e7
+dotnetLinuxARM64ComponentName=${dotnetComponentName} arm64 Checksum (SHA512) ${dotnetLinuxARM64ComponentSHA512}
+
+# https://dotnet.microsoft.com/download/dotnet/3.1
+dotnetLinuxARM64ComponentVersion_31=${dotnetComponentVersion_31}
+dotnetLinuxARM64Component_31=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/Runtime/${dotnetComponentVersion_31}/dotnet-runtime-${dotnetComponentVersion_31}-linux-arm64.tar.gz
+dotnetLinuxARM64ComponentSHA512_31=80971125650a2fa0163e39a2de98bc2e871c295b723559e6081a3ab59d99195aa5b794450f8182c5eb4e7e472ca1c13340ef1cc8a5588114c494bbb5981f19c4
+dotnetLinuxARM64ComponentName_31=${dotnetComponentName_31} arm64 Checksum (SHA512) ${dotnetLinuxARM64ComponentSHA512_31}
+
+# https://dotnet.microsoft.com/download/dotnet/5.0
+dotnetLinuxARM64ComponentVersion_50=${dotnetComponentVersion_50}
+dotnetLinuxARM64Component_50=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/Runtime/${dotnetComponentVersion_50}/dotnet-runtime-${dotnetComponentVersion_50}-linux-arm64.tar.gz
+dotnetLinuxARM64ComponentSHA512_50=a8089fad8d21a4b582aa6c3d7162d56a21fee697fd400f050a772f67c2ace5e4196d1c4261d3e861d6dc2e5439666f112c406104d6271e5ab60cda80ef2ffc64
+dotnetLinuxARM64ComponentName_50=${dotnetComponentName_50} arm65 Checksum (SHA512) ${dotnetLinuxARM64ComponentSHA512_50}

--- a/configs/windows.config
+++ b/configs/windows.config
@@ -19,19 +19,19 @@ jdkWindowsComponentName=JDK <img align="center" height="18" src="/logo/corretto.
 dotnetWindowsComponentVersion=${dotnetComponentVersion}
 dotnetWindowsComponent=https://${proxyUrl}dotnetcli.blob.core.windows.net/dotnet/Sdk/${dotnetComponentVersion}/dotnet-sdk-${dotnetComponentVersion}-win-x64.zip
 dotnetWindowsComponentSHA512=d2fa2f0d2b4550ac3408b924ab356add378af1d0f639623f0742e37f57b3f2b525d81f5d5c029303b6d95fed516b04a7b6c3a98f27f770fc8b4e76414cf41660
-dotnetWindowsComponentName=${dotnetComponentName} Checksum (SHA512) ${dotnetWindowsComponentSHA512}
+dotnetWindowsComponentName=${dotnetComponentName} x86 Checksum (SHA512) ${dotnetWindowsComponentSHA512}
 
 # https://dotnet.microsoft.com/download/dotnet/3.1
 dotnetWindowsComponentVersion_31=${dotnetComponentVersion_31}
 dotnetWindowsComponent_31=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/Runtime/${dotnetComponentVersion_31}/dotnet-runtime-${dotnetComponentVersion_31}-win-x64.zip
 dotnetWindowsComponentSHA512_31=7ba766b2f388ab09beee6a465f1eeb6b9a6858c8b6da51dacc79622b110558ef6211a40e715a16b526f2da08216c99143570b8253ff2c5ad874400475d1feb44
-dotnetWindowsComponentName_31=${dotnetComponentName_31} Checksum (SHA512) ${dotnetWindowsComponentSHA512_31}
+dotnetWindowsComponentName_31=${dotnetComponentName_31} x86 Checksum (SHA512) ${dotnetWindowsComponentSHA512_31}
 
 # https://dotnet.microsoft.com/download/dotnet/5.0
 dotnetWindowsComponentVersion_50=${dotnetComponentVersion_50}
 dotnetWindowsComponent_50=https://${proxyUrl}dotnetcli.azureedge.net/dotnet/Runtime/${dotnetComponentVersion_50}/dotnet-runtime-${dotnetComponentVersion_50}-win-x64.zip
 dotnetWindowsComponentSHA512_50=636f22bfbfd98c80c96f2fc3815beb42ee2699cf2a410eeba24ddcc9304bc39594260eca4061b012d4b02b9c4592fa6927343077df053343a9c344a9289658e1
-dotnetWindowsComponentName_50=${dotnetComponentName_50} Checksum (SHA512) ${dotnetWindowsComponentSHA512_50}
+dotnetWindowsComponentName_50=${dotnetComponentName_50} x86 Checksum (SHA512) ${dotnetWindowsComponentSHA512_50}
 
 mercurialWindowsComponentName=Mercurial x64 v.5.9.1
 mercurialWindowsComponent=https://${proxyUrl}www.mercurial-scm.org/release/windows/mercurial-5.9.1-x64.msi


### PR DESCRIPTION
# ARM support for sudo and non-sudo agents

As mentioned in quite a few YouTrack issues[^1], ARM support is rather lacklustre, as only the server and the minimal-agent is available for building, and none is present on DockerHub.

I made changes to make an ARM build of the teamcity-agent possible and consistent with other builds:
- created configuration files for both 18.04 and 20.04 UbuntuARM builds with _Perforce_ removed as it does not provide an arm64 binary as of now (2021.2/2273812)
- modified `linuxARM.config` with arm64 dotnet binaries
- modified `common.config`, `linux.config` and `windows.config` for more consistent dotnet descriptions
- 20.04 images now default to a tag that does not include aformentioned version number
- ~~added newly the generated files~~

[^1]:  [TW-68887](https://youtrack.jetbrains.com/issue/TW-68887/Docker-image.-Support-ARM-architecture-(AWS-ECS-Graviton-ARM)) Docker image. Support ARM architecture (AWS ECS Graviton ARM), [TW-74465](https://youtrack.jetbrains.com/issue/TW-74465/Teamcity-agent-ARM64-v8) Teamcity-agent ARM64/v8
