### PR TITLE
[Automation] Docker Image Validation - re-generated build configuration DSLs

### DIFF
--- a/.teamcity/generated/HubProject.kts
+++ b/.teamcity/generated/HubProject.kts
@@ -1,14 +1,27 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object HubProject : Project({
 name = "Docker hub"

--- a/.teamcity/generated/HubProject.kts
+++ b/.teamcity/generated/HubProject.kts
@@ -24,8 +24,8 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object HubProject : Project({
-name = "Docker hub"
-buildType(PushHubLinux.push_hub_linux)
-buildType(PushHubWindows.push_hub_windows)
-buildType(PublishHubVersion.publish_hub_version)
+	 name = "Docker hub"
+	 buildType(PushHubLinux.push_hub_linux)
+	 buildType(PushHubWindows.push_hub_windows)
+	 buildType(PublishHubVersion.publish_hub_version)
 })

--- a/.teamcity/generated/ImageValidation.kts
+++ b/.teamcity/generated/ImageValidation.kts
@@ -23,8 +23,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object image_validation: BuildType(
-{
+object image_validation: BuildType({
 	 name = "Validation of Size Regression - Staging Docker Images (Windows / Linux)"
 	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 	 vcs {

--- a/.teamcity/generated/ImageValidation.kts
+++ b/.teamcity/generated/ImageValidation.kts
@@ -1,95 +1,105 @@
 // NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
 // ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
-import common.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
+object image_validation: BuildType(
+{
+	 name = "Validation of Size Regression - Staging Docker Images (Windows / Linux)"
+	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 vcs {
+		 root(TeamCityDockerImagesRepo.TeamCityDockerImagesRepo)
+	 }
 
-object image_validation: BuildType({
+	 triggers {
+		 // Execute the build once the images are available within %deployRepository%
+		 finishBuildTrigger {
+			 buildType = "${PublishHubVersion.publish_hub_version.id}"
+		 }
+	 }
 
-	name = "Validation of Size Regression - Staging Docker Images (Windows / Linux)"
-	buildNumberPattern="test-%build.counter%"
+	 params {
+		 // -- inherited parameter, removed in debug purposes
+		 param("dockerImage.teamcity.buildNumber", "-")
+	 }
 
-	vcs {
-		root(TeamCityDockerImagesRepo.TeamCityDockerImagesRepo)
-	}
+	 val images = listOf(
+"%docker.deployRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux", 
+		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo", 
+		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64", 
+		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux", 
+		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo", 
+		"%docker.deployRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux", 
+		"%docker.deployRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809", 
+		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809", 
+		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809", 
+		"%docker.deployRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809", 
+		"%docker.deployRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004", 
+		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004", 
+		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004", 
+		"%docker.deployRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+	  )
 
-	triggers {
-		// Execute the build once the images are available within %deployRepository%
-		finishBuildTrigger {
-			buildType = "${PublishLocal.publish_local.id}"
-		}
-	}
+	 steps {
+		   images.forEach { imageFqdn ->
+		     // Generate validation for each image fully-qualified domain name (FQDN)
+		     gradle {
+			       name = "Image Verification Gradle - $imageFqdn"
+			       tasks = "clean build run --args=\"validate  $imageFqdn %docker.stagingRepository.login% %docker.stagingRepository.token%\""
+			       workingDir = "tool/automation/framework"
+			       buildFile = "build.gradle"
+			       jdkHome = "%env.JDK_11_x64%"
+			       executionMode = BuildStep.ExecutionMode.ALWAYS
+			     }
+		   }
+	 }
 
-	params {
-		// Inherited parameter, not used within build configuration, thus removed in order to ...
-		// ... prevent unnecessary dependency.
-		param("dockerImage.teamcity.buildNumber", "-")
-	}
+	 failureConditions {
+		   // Failed in case the validation via framework didn't succeed
+		   failOnText {
+			     conditionType = BuildFailureOnText.ConditionType.CONTAINS
+			     pattern = "DockerImageValidationException"
+			     failureMessage = "Docker Image validation have failed"
+			     // allows the steps to continue running even in case of one problem
+			     reportOnlyFirstMatch = false
+		   }
+	 }
 
-	val images = listOf("%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:2022.10-windowsservercore-1809",
-		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:2022.10-nanoserver-1809",
-		"%docker.deployRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2022.10-nanoserver-1809",
-		"%docker.deployRepository%teamcity-server%docker.buildImagePostfix%:2022.10-nanoserver-2004",
-		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:2022.10-windowsservercore-2004",
-		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:2022.10-nanoserver-2004",
-		"%docker.deployRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2022.10-nanoserver-2004",
-		// -- linux images
-		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:2022.10-linux",
-		"%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:2022.10-linux-sudo",
-		"%docker.deployRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2022.10-linux"
-	)
+	 requirements {
+		  exists("env.JDK_11")
+		  // Images are validated mostly via DockerHub REST API. In case ...
+		  // ... Docker agent will be used, platform-compatibility must be addressed, ...
+		  // ... especially in case of Windows images.
+		  contains("teamcity.agent.jvm.os.name", "Linux")
+	 }
 
-	steps {
-		images.forEach { imageFqdn ->
-			// Generate validation for each image fully-qualified domain name (FQDN)
-			gradle {
-				name = "Image Verification Gradle - $imageFqdn"
-				tasks = "clean build run --args=\"validate  $imageFqdn %docker.stagingRepository.login% %docker.stagingRepository.token%\""
-
-				workingDir = "tool/automation/framework"
-				buildFile = "build.gradle"
-				jdkHome = "%env.JDK_11_x64%"
-				executionMode = BuildStep.ExecutionMode.ALWAYS
-			}
-		}
-	}
-
-	failureConditions {
-		// Failed in case the validation via framework didn't succeed
-		failOnText {
-			conditionType = BuildFailureOnText.ConditionType.CONTAINS
-			pattern = "DockerImageValidationException"
-			failureMessage = "Docker Image validation have failed"
-			// allows the steps to continue running even in case of one problem
-			reportOnlyFirstMatch = false
-		}
-	}
-
-	requirements {
-		exists("env.JDK_11")
-		// Images are validated mostly via DockerHub REST API. In case ...
-		// ... Docker agent will be used, platform-compatibility must be addressed, ...
-		// ... especially in case of Windows images.
-		contains("teamcity.agent.jvm.os.name", "Linux")
-	}
-
-	features {
-		dockerSupport {
-			cleanupPushedImages = true
-			loginToRegistry = on {
-				dockerRegistryId = "PROJECT_EXT_774,PROJECT_EXT_315"
-			}
-		}
-	}
+	 features {
+		   dockerSupport {
+			     cleanupPushedImages = true
+			     loginToRegistry = on {
+			       dockerRegistryId = "PROJECT_EXT_774,PROJECT_EXT_315"
+			     }
+		   }
+	 }
 })
+

--- a/.teamcity/generated/LocalProject.kts
+++ b/.teamcity/generated/LocalProject.kts
@@ -1,24 +1,37 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object LocalProject : Project({
-    name = "Staging registry"
-    buildType(PushLocalLinux1804.push_local_linux_18_04)
-    buildType(PushLocalLinux2004.push_local_linux_20_04)
-    buildType(PushLocalWindows1803.push_local_windows_1803)
-    buildType(PushLocalWindows1809.push_local_windows_1809)
-    buildType(PushLocalWindows1903.push_local_windows_1903)
-    buildType(PushLocalWindows1909.push_local_windows_1909)
-    buildType(PushLocalWindows2004.push_local_windows_2004)
-    buildType(PublishLocal.publish_local)
-    buildType(ImageValidation.image_validation)
+name = "Staging registry"
+buildType(PushLocalLinux1804.push_local_linux_18_04)
+buildType(PushLocalLinux2004.push_local_linux_20_04)
+buildType(PushLocalWindows1803.push_local_windows_1803)
+buildType(PushLocalWindows1809.push_local_windows_1809)
+buildType(PushLocalWindows1903.push_local_windows_1903)
+buildType(PushLocalWindows1909.push_local_windows_1909)
+buildType(PushLocalWindows2004.push_local_windows_2004)
+buildType(PublishLocal.publish_local)
+buildType(ImageValidation.image_validation)
 })

--- a/.teamcity/generated/LocalProject.kts
+++ b/.teamcity/generated/LocalProject.kts
@@ -24,14 +24,14 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object LocalProject : Project({
-name = "Staging registry"
-buildType(PushLocalLinux1804.push_local_linux_18_04)
-buildType(PushLocalLinux2004.push_local_linux_20_04)
-buildType(PushLocalWindows1803.push_local_windows_1803)
-buildType(PushLocalWindows1809.push_local_windows_1809)
-buildType(PushLocalWindows1903.push_local_windows_1903)
-buildType(PushLocalWindows1909.push_local_windows_1909)
-buildType(PushLocalWindows2004.push_local_windows_2004)
-buildType(PublishLocal.publish_local)
-buildType(ImageValidation.image_validation)
+	 name = "Staging registry"
+	 buildType(PushLocalLinux1804.push_local_linux_18_04)
+	 buildType(PushLocalLinux2004.push_local_linux_20_04)
+	 buildType(PushLocalWindows1803.push_local_windows_1803)
+	 buildType(PushLocalWindows1809.push_local_windows_1809)
+	 buildType(PushLocalWindows1903.push_local_windows_1903)
+	 buildType(PushLocalWindows1909.push_local_windows_1909)
+	 buildType(PushLocalWindows2004.push_local_windows_2004)
+	 buildType(PublishLocal.publish_local)
+	 buildType(ImageValidation.image_validation)
 })

--- a/.teamcity/generated/PublishHubVersion.kts
+++ b/.teamcity/generated/PublishHubVersion.kts
@@ -23,131 +23,130 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object publish_hub_version: BuildType(
-{
-name = "Publish as version"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-enablePersonalBuilds = false
-type = BuildTypeSettings.Type.DEPLOYMENT
-maxRunningBuilds = 1
-steps {
-	script {
-		 name = "remove manifests"
-		 scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
+object publish_hub_version: BuildType({
+	 name = "Publish as version"
+	buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 enablePersonalBuilds = false
+	 type = BuildTypeSettings.Type.DEPLOYMENT
+	 maxRunningBuilds = 1
+	 steps {
+		 script {
+		 	 name = "remove manifests"
+		 	 scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
+		 }
+	dockerCommand {
+		 name = "manifest create teamcity-server:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "create %docker.deployRepository%teamcity-server:EAP %docker.deployRepository%teamcity-server:EAP-linux %docker.deployRepository%teamcity-server:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
+		 }
 	}
-dockerCommand {
-	 name = "manifest create teamcity-server:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "create %docker.deployRepository%teamcity-server:EAP %docker.deployRepository%teamcity-server:EAP-linux %docker.deployRepository%teamcity-server:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
+	dockerCommand {
+		 name = "manifest push teamcity-server:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "push %docker.deployRepository%teamcity-server:EAP"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest inspect teamcity-server:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "inspect %docker.deployRepository%teamcity-server:EAP --verbose"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest create teamcity-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP %docker.deployRepository%teamcity-agent:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest push teamcity-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "push %docker.deployRepository%teamcity-agent:EAP"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest inspect teamcity-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP --verbose"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest create teamcity-minimal-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "create %docker.deployRepository%teamcity-minimal-agent:EAP %docker.deployRepository%teamcity-minimal-agent:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest push teamcity-minimal-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "push %docker.deployRepository%teamcity-minimal-agent:EAP"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest inspect teamcity-minimal-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "inspect %docker.deployRepository%teamcity-minimal-agent:EAP --verbose"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest create teamcity-agent:EAP-windowsservercore"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP-windowsservercore %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest push teamcity-agent:EAP-windowsservercore"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "push %docker.deployRepository%teamcity-agent:EAP-windowsservercore"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest inspect teamcity-agent:EAP-windowsservercore"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP-windowsservercore --verbose"
+		 }
+	}
 	 }
-}
-dockerCommand {
-	 name = "manifest push teamcity-server:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "push %docker.deployRepository%teamcity-server:EAP"
+		 dependencies {
+			 snapshot(AbsoluteId("TC_Trunk_BuildDistDocker")) {
+
+				 reuseBuilds = ReuseBuilds.ANY 
+ 			 onDependencyFailure = FailureAction.IGNORE 
 	 }
-}
-dockerCommand {
-	 name = "manifest inspect teamcity-server:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "inspect %docker.deployRepository%teamcity-server:EAP --verbose"
-	 }
-}
-dockerCommand {
-	 name = "manifest create teamcity-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP %docker.deployRepository%teamcity-agent:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
-	 }
-}
-dockerCommand {
-	 name = "manifest push teamcity-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "push %docker.deployRepository%teamcity-agent:EAP"
-	 }
-}
-dockerCommand {
-	 name = "manifest inspect teamcity-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP --verbose"
-	 }
-}
-dockerCommand {
-	 name = "manifest create teamcity-minimal-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "create %docker.deployRepository%teamcity-minimal-agent:EAP %docker.deployRepository%teamcity-minimal-agent:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
-	 }
-}
-dockerCommand {
-	 name = "manifest push teamcity-minimal-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "push %docker.deployRepository%teamcity-minimal-agent:EAP"
-	 }
-}
-dockerCommand {
-	 name = "manifest inspect teamcity-minimal-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "inspect %docker.deployRepository%teamcity-minimal-agent:EAP --verbose"
-	 }
-}
-dockerCommand {
-	 name = "manifest create teamcity-agent:EAP-windowsservercore"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP-windowsservercore %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
-	 }
-}
-dockerCommand {
-	 name = "manifest push teamcity-agent:EAP-windowsservercore"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "push %docker.deployRepository%teamcity-agent:EAP-windowsservercore"
-	 }
-}
-dockerCommand {
-	 name = "manifest inspect teamcity-agent:EAP-windowsservercore"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP-windowsservercore --verbose"
-	 }
-}
-}
-dependencies {
-	 snapshot(AbsoluteId("TC_Trunk_BuildDistDocker"))
-{
- 	 reuseBuilds = ReuseBuilds.ANY
-onDependencyFailure = FailureAction.IGNORE
-}
-	 snapshot(PushHubLinux.push_hub_linux)
-{
- 	 onDependencyFailure =  FailureAction.FAIL_TO_START
-}
-	 snapshot(PushHubWindows.push_hub_windows)
-{
- 	 onDependencyFailure =  FailureAction.FAIL_TO_START
-}
-}
-requirements {
-noLessThanVer("docker.version", "18.05.0")
-contains("docker.server.osType", "windows")
-contains("system.agent.name", "docker")
-contains("system.agent.name", "windows10")
-}
-features {
-dockerSupport {
-	 cleanupPushedImages = true
-	 loginToRegistry = on {
-		 dockerRegistryId = "PROJECT_EXT_774"
-	 }
-}
-}
+			 snapshot(PushHubLinux.push_hub_linux) {
+
+				 onDependencyFailure =  FailureAction.FAIL_TO_START 
+ 		 }
+			 snapshot(PushHubWindows.push_hub_windows) {
+
+				 onDependencyFailure =  FailureAction.FAIL_TO_START 
+ 		 }
+		 }
+	requirements {
+		 noLessThanVer("docker.version", "18.05.0")
+		 contains("docker.server.osType", "windows")
+		 contains("system.agent.name", "docker")
+		 contains("system.agent.name", "windows10")
+	}
+	 features {
+		 dockerSupport {
+		 	 cleanupPushedImages = true
+		 	 loginToRegistry = on {
+		 		 dockerRegistryId = "PROJECT_EXT_774"
+		 	 }
+		 }
+	}
 })
 

--- a/.teamcity/generated/PublishHubVersion.kts
+++ b/.teamcity/generated/PublishHubVersion.kts
@@ -1,14 +1,27 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object publish_hub_version: BuildType(
 {
@@ -18,108 +31,108 @@ enablePersonalBuilds = false
 type = BuildTypeSettings.Type.DEPLOYMENT
 maxRunningBuilds = 1
 steps {
-script {
-name = "remove manifests"
-scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
+	script {
+		 name = "remove manifests"
+		 scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
+	}
+dockerCommand {
+	 name = "manifest create teamcity-server:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "create %docker.deployRepository%teamcity-server:EAP %docker.deployRepository%teamcity-server:EAP-linux %docker.deployRepository%teamcity-server:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
+	 }
 }
 dockerCommand {
-name = "manifest create teamcity-server:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "create %docker.deployRepository%teamcity-server:EAP %docker.deployRepository%teamcity-server:EAP-linux %docker.deployRepository%teamcity-server:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
-}
-}
-dockerCommand {
-name = "manifest push teamcity-server:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "push %docker.deployRepository%teamcity-server:EAP"
-}
+	 name = "manifest push teamcity-server:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "push %docker.deployRepository%teamcity-server:EAP"
+	 }
 }
 dockerCommand {
-name = "manifest inspect teamcity-server:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "inspect %docker.deployRepository%teamcity-server:EAP --verbose"
-}
-}
-dockerCommand {
-name = "manifest create teamcity-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "create %docker.deployRepository%teamcity-agent:EAP %docker.deployRepository%teamcity-agent:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
-}
+	 name = "manifest inspect teamcity-server:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "inspect %docker.deployRepository%teamcity-server:EAP --verbose"
+	 }
 }
 dockerCommand {
-name = "manifest push teamcity-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "push %docker.deployRepository%teamcity-agent:EAP"
-}
-}
-dockerCommand {
-name = "manifest inspect teamcity-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP --verbose"
-}
+	 name = "manifest create teamcity-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP %docker.deployRepository%teamcity-agent:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
+	 }
 }
 dockerCommand {
-name = "manifest create teamcity-minimal-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "create %docker.deployRepository%teamcity-minimal-agent:EAP %docker.deployRepository%teamcity-minimal-agent:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
-}
-}
-dockerCommand {
-name = "manifest push teamcity-minimal-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "push %docker.deployRepository%teamcity-minimal-agent:EAP"
-}
+	 name = "manifest push teamcity-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "push %docker.deployRepository%teamcity-agent:EAP"
+	 }
 }
 dockerCommand {
-name = "manifest inspect teamcity-minimal-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "inspect %docker.deployRepository%teamcity-minimal-agent:EAP --verbose"
-}
-}
-dockerCommand {
-name = "manifest create teamcity-agent:EAP-windowsservercore"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "create %docker.deployRepository%teamcity-agent:EAP-windowsservercore %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
-}
+	 name = "manifest inspect teamcity-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP --verbose"
+	 }
 }
 dockerCommand {
-name = "manifest push teamcity-agent:EAP-windowsservercore"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "push %docker.deployRepository%teamcity-agent:EAP-windowsservercore"
-}
+	 name = "manifest create teamcity-minimal-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "create %docker.deployRepository%teamcity-minimal-agent:EAP %docker.deployRepository%teamcity-minimal-agent:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
+	 }
 }
 dockerCommand {
-name = "manifest inspect teamcity-agent:EAP-windowsservercore"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP-windowsservercore --verbose"
+	 name = "manifest push teamcity-minimal-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "push %docker.deployRepository%teamcity-minimal-agent:EAP"
+	 }
 }
+dockerCommand {
+	 name = "manifest inspect teamcity-minimal-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "inspect %docker.deployRepository%teamcity-minimal-agent:EAP --verbose"
+	 }
+}
+dockerCommand {
+	 name = "manifest create teamcity-agent:EAP-windowsservercore"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP-windowsservercore %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
+	 }
+}
+dockerCommand {
+	 name = "manifest push teamcity-agent:EAP-windowsservercore"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "push %docker.deployRepository%teamcity-agent:EAP-windowsservercore"
+	 }
+}
+dockerCommand {
+	 name = "manifest inspect teamcity-agent:EAP-windowsservercore"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP-windowsservercore --verbose"
+	 }
 }
 }
 dependencies {
-snapshot(AbsoluteId("TC_Trunk_BuildDistDocker"))
+	 snapshot(AbsoluteId("TC_Trunk_BuildDistDocker"))
 {
-reuseBuilds = ReuseBuilds.ANY
+ 	 reuseBuilds = ReuseBuilds.ANY
 onDependencyFailure = FailureAction.IGNORE
 }
-snapshot(PushHubLinux.push_hub_linux)
+	 snapshot(PushHubLinux.push_hub_linux)
 {
-onDependencyFailure =  FailureAction.FAIL_TO_START
+ 	 onDependencyFailure =  FailureAction.FAIL_TO_START
 }
-snapshot(PushHubWindows.push_hub_windows)
+	 snapshot(PushHubWindows.push_hub_windows)
 {
-onDependencyFailure =  FailureAction.FAIL_TO_START
+ 	 onDependencyFailure =  FailureAction.FAIL_TO_START
 }
 }
 requirements {
@@ -130,10 +143,10 @@ contains("system.agent.name", "windows10")
 }
 features {
 dockerSupport {
-cleanupPushedImages = true
-loginToRegistry = on {
-dockerRegistryId = "PROJECT_EXT_774"
-}
+	 cleanupPushedImages = true
+	 loginToRegistry = on {
+		 dockerRegistryId = "PROJECT_EXT_774"
+	 }
 }
 }
 })

--- a/.teamcity/generated/PublishHubVersion.kts
+++ b/.teamcity/generated/PublishHubVersion.kts
@@ -38,84 +38,84 @@ steps {
 dockerCommand {
 	 name = "manifest create teamcity-server:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "create %docker.deployRepository%teamcity-server:EAP %docker.deployRepository%teamcity-server:EAP-linux %docker.deployRepository%teamcity-server:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
 	 }
 }
 dockerCommand {
 	 name = "manifest push teamcity-server:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "push %docker.deployRepository%teamcity-server:EAP"
 	 }
 }
 dockerCommand {
 	 name = "manifest inspect teamcity-server:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "inspect %docker.deployRepository%teamcity-server:EAP --verbose"
 	 }
 }
 dockerCommand {
 	 name = "manifest create teamcity-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP %docker.deployRepository%teamcity-agent:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
 	 }
 }
 dockerCommand {
 	 name = "manifest push teamcity-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "push %docker.deployRepository%teamcity-agent:EAP"
 	 }
 }
 dockerCommand {
 	 name = "manifest inspect teamcity-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP --verbose"
 	 }
 }
 dockerCommand {
 	 name = "manifest create teamcity-minimal-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "create %docker.deployRepository%teamcity-minimal-agent:EAP %docker.deployRepository%teamcity-minimal-agent:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
 	 }
 }
 dockerCommand {
 	 name = "manifest push teamcity-minimal-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "push %docker.deployRepository%teamcity-minimal-agent:EAP"
 	 }
 }
 dockerCommand {
 	 name = "manifest inspect teamcity-minimal-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "inspect %docker.deployRepository%teamcity-minimal-agent:EAP --verbose"
 	 }
 }
 dockerCommand {
 	 name = "manifest create teamcity-agent:EAP-windowsservercore"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP-windowsservercore %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
 	 }
 }
 dockerCommand {
 	 name = "manifest push teamcity-agent:EAP-windowsservercore"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "push %docker.deployRepository%teamcity-agent:EAP-windowsservercore"
 	 }
 }
 dockerCommand {
 	 name = "manifest inspect teamcity-agent:EAP-windowsservercore"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP-windowsservercore --verbose"
 	 }
 }

--- a/.teamcity/generated/PublishLocal.kts
+++ b/.teamcity/generated/PublishLocal.kts
@@ -38,84 +38,84 @@ steps {
 dockerCommand {
 	 name = "manifest create teamcity-server:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
 	 }
 }
 dockerCommand {
 	 name = "manifest push teamcity-server:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "push %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP"
 	 }
 }
 dockerCommand {
 	 name = "manifest inspect teamcity-server:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "inspect %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP --verbose"
 	 }
 }
 dockerCommand {
 	 name = "manifest create teamcity-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 	 }
 }
 dockerCommand {
 	 name = "manifest push teamcity-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP"
 	 }
 }
 dockerCommand {
 	 name = "manifest inspect teamcity-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP --verbose"
 	 }
 }
 dockerCommand {
 	 name = "manifest create teamcity-minimal-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 	 }
 }
 dockerCommand {
 	 name = "manifest push teamcity-minimal-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "push %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP"
 	 }
 }
 dockerCommand {
 	 name = "manifest inspect teamcity-minimal-agent:EAP"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "inspect %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP --verbose"
 	 }
 }
 dockerCommand {
 	 name = "manifest create teamcity-agent:EAP-windowsservercore"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
 	 }
 }
 dockerCommand {
 	 name = "manifest push teamcity-agent:EAP-windowsservercore"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore"
 	 }
 }
 dockerCommand {
 	 name = "manifest inspect teamcity-agent:EAP-windowsservercore"
 	 commandType = other {
-	 subCommand = "manifest"
+		 subCommand = "manifest"
 		 commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore --verbose"
 	 }
 }

--- a/.teamcity/generated/PublishLocal.kts
+++ b/.teamcity/generated/PublishLocal.kts
@@ -1,14 +1,27 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object publish_local: BuildType(
 {
@@ -18,113 +31,113 @@ enablePersonalBuilds = false
 type = BuildTypeSettings.Type.DEPLOYMENT
 maxRunningBuilds = 1
 steps {
-script {
-name = "remove manifests"
-scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
+	script {
+		 name = "remove manifests"
+		 scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
+	}
+dockerCommand {
+	 name = "manifest create teamcity-server:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+	 }
 }
 dockerCommand {
-name = "manifest create teamcity-server:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-}
-}
-dockerCommand {
-name = "manifest push teamcity-server:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "push %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP"
-}
+	 name = "manifest push teamcity-server:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "push %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP"
+	 }
 }
 dockerCommand {
-name = "manifest inspect teamcity-server:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "inspect %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP --verbose"
-}
-}
-dockerCommand {
-name = "manifest create teamcity-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-}
+	 name = "manifest inspect teamcity-server:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "inspect %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP --verbose"
+	 }
 }
 dockerCommand {
-name = "manifest push teamcity-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP"
-}
-}
-dockerCommand {
-name = "manifest inspect teamcity-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP --verbose"
-}
+	 name = "manifest create teamcity-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+	 }
 }
 dockerCommand {
-name = "manifest create teamcity-minimal-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-}
-}
-dockerCommand {
-name = "manifest push teamcity-minimal-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "push %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP"
-}
+	 name = "manifest push teamcity-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP"
+	 }
 }
 dockerCommand {
-name = "manifest inspect teamcity-minimal-agent:EAP"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "inspect %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP --verbose"
-}
-}
-dockerCommand {
-name = "manifest create teamcity-agent:EAP-windowsservercore"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-}
+	 name = "manifest inspect teamcity-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP --verbose"
+	 }
 }
 dockerCommand {
-name = "manifest push teamcity-agent:EAP-windowsservercore"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore"
-}
+	 name = "manifest create teamcity-minimal-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+	 }
 }
 dockerCommand {
-name = "manifest inspect teamcity-agent:EAP-windowsservercore"
-commandType = other {
-subCommand = "manifest"
-commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore --verbose"
+	 name = "manifest push teamcity-minimal-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "push %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP"
+	 }
 }
+dockerCommand {
+	 name = "manifest inspect teamcity-minimal-agent:EAP"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "inspect %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP --verbose"
+	 }
+}
+dockerCommand {
+	 name = "manifest create teamcity-agent:EAP-windowsservercore"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+	 }
+}
+dockerCommand {
+	 name = "manifest push teamcity-agent:EAP-windowsservercore"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore"
+	 }
+}
+dockerCommand {
+	 name = "manifest inspect teamcity-agent:EAP-windowsservercore"
+	 commandType = other {
+	 subCommand = "manifest"
+		 commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore --verbose"
+	 }
 }
 }
 dependencies {
-snapshot(AbsoluteId("TC_Trunk_BuildDistDocker"))
+	 snapshot(AbsoluteId("TC_Trunk_BuildDistDocker"))
 {
-onDependencyFailure = FailureAction.FAIL_TO_START
+ 	 onDependencyFailure = FailureAction.FAIL_TO_START
 reuseBuilds = ReuseBuilds.ANY
 synchronizeRevisions = false
 }
-snapshot(PushLocalLinux2004.push_local_linux_20_04)
+	 snapshot(PushLocalLinux2004.push_local_linux_20_04)
 {
-onDependencyFailure =  FailureAction.FAIL_TO_START
+ 	 onDependencyFailure =  FailureAction.FAIL_TO_START
 }
-snapshot(PushLocalWindows1809.push_local_windows_1809)
+	 snapshot(PushLocalWindows1809.push_local_windows_1809)
 {
-onDependencyFailure =  FailureAction.FAIL_TO_START
+ 	 onDependencyFailure =  FailureAction.FAIL_TO_START
 }
-snapshot(PushLocalWindows2004.push_local_windows_2004)
+	 snapshot(PushLocalWindows2004.push_local_windows_2004)
 {
-onDependencyFailure =  FailureAction.FAIL_TO_START
+ 	 onDependencyFailure =  FailureAction.FAIL_TO_START
 }
 }
 requirements {
@@ -135,10 +148,10 @@ contains("system.agent.name", "windows10")
 }
 features {
 dockerSupport {
-cleanupPushedImages = true
-loginToRegistry = on {
-dockerRegistryId = "PROJECT_EXT_774"
-}
+	 cleanupPushedImages = true
+	 loginToRegistry = on {
+		 dockerRegistryId = "PROJECT_EXT_774"
+	 }
 }
 }
 })

--- a/.teamcity/generated/PublishLocal.kts
+++ b/.teamcity/generated/PublishLocal.kts
@@ -23,136 +23,135 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object publish_local: BuildType(
-{
-name = "Publish"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-enablePersonalBuilds = false
-type = BuildTypeSettings.Type.DEPLOYMENT
-maxRunningBuilds = 1
-steps {
-	script {
-		 name = "remove manifests"
-		 scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
+object publish_local: BuildType({
+	 name = "Publish"
+	buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 enablePersonalBuilds = false
+	 type = BuildTypeSettings.Type.DEPLOYMENT
+	 maxRunningBuilds = 1
+	 steps {
+		 script {
+		 	 name = "remove manifests"
+		 	 scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
+		 }
+	dockerCommand {
+		 name = "manifest create teamcity-server:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 }
 	}
-dockerCommand {
-	 name = "manifest create teamcity-server:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+	dockerCommand {
+		 name = "manifest push teamcity-server:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "push %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest inspect teamcity-server:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "inspect %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP --verbose"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest create teamcity-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest push teamcity-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest inspect teamcity-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP --verbose"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest create teamcity-minimal-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest push teamcity-minimal-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "push %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest inspect teamcity-minimal-agent:EAP"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "inspect %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP --verbose"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest create teamcity-agent:EAP-windowsservercore"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest push teamcity-agent:EAP-windowsservercore"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore"
+		 }
+	}
+	dockerCommand {
+		 name = "manifest inspect teamcity-agent:EAP-windowsservercore"
+		 commandType = other {
+			 subCommand = "manifest"
+			 commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore --verbose"
+		 }
+	}
 	 }
-}
-dockerCommand {
-	 name = "manifest push teamcity-server:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "push %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP"
-	 }
-}
-dockerCommand {
-	 name = "manifest inspect teamcity-server:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "inspect %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP --verbose"
-	 }
-}
-dockerCommand {
-	 name = "manifest create teamcity-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-	 }
-}
-dockerCommand {
-	 name = "manifest push teamcity-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP"
-	 }
-}
-dockerCommand {
-	 name = "manifest inspect teamcity-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP --verbose"
-	 }
-}
-dockerCommand {
-	 name = "manifest create teamcity-minimal-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-	 }
-}
-dockerCommand {
-	 name = "manifest push teamcity-minimal-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "push %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP"
-	 }
-}
-dockerCommand {
-	 name = "manifest inspect teamcity-minimal-agent:EAP"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "inspect %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP --verbose"
-	 }
-}
-dockerCommand {
-	 name = "manifest create teamcity-agent:EAP-windowsservercore"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-	 }
-}
-dockerCommand {
-	 name = "manifest push teamcity-agent:EAP-windowsservercore"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore"
-	 }
-}
-dockerCommand {
-	 name = "manifest inspect teamcity-agent:EAP-windowsservercore"
-	 commandType = other {
-		 subCommand = "manifest"
-		 commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore --verbose"
-	 }
-}
-}
-dependencies {
-	 snapshot(AbsoluteId("TC_Trunk_BuildDistDocker"))
-{
- 	 onDependencyFailure = FailureAction.FAIL_TO_START
-reuseBuilds = ReuseBuilds.ANY
-synchronizeRevisions = false
-}
-	 snapshot(PushLocalLinux2004.push_local_linux_20_04)
-{
- 	 onDependencyFailure =  FailureAction.FAIL_TO_START
-}
-	 snapshot(PushLocalWindows1809.push_local_windows_1809)
-{
- 	 onDependencyFailure =  FailureAction.FAIL_TO_START
-}
-	 snapshot(PushLocalWindows2004.push_local_windows_2004)
-{
- 	 onDependencyFailure =  FailureAction.FAIL_TO_START
-}
-}
-requirements {
-noLessThanVer("docker.version", "18.05.0")
-contains("docker.server.osType", "windows")
-contains("system.agent.name", "docker")
-contains("system.agent.name", "windows10")
-}
-features {
-dockerSupport {
-	 cleanupPushedImages = true
-	 loginToRegistry = on {
-		 dockerRegistryId = "PROJECT_EXT_774"
-	 }
-}
-}
+		 dependencies {
+			 snapshot(AbsoluteId("TC_Trunk_BuildDistDocker")) {
+
+				 onDependencyFailure = FailureAction.FAIL_TO_START 
+ 			 reuseBuilds = ReuseBuilds.ANY 
+ 			 synchronizeRevisions = false 
+ 		 }
+			 snapshot(PushLocalLinux2004.push_local_linux_20_04) {
+
+				 onDependencyFailure =  FailureAction.FAIL_TO_START 
+ 		 }
+			 snapshot(PushLocalWindows1809.push_local_windows_1809) {
+
+				 onDependencyFailure =  FailureAction.FAIL_TO_START 
+ 		 }
+			 snapshot(PushLocalWindows2004.push_local_windows_2004) {
+
+				 onDependencyFailure =  FailureAction.FAIL_TO_START 
+ 		 }
+		 }
+	requirements {
+		 noLessThanVer("docker.version", "18.05.0")
+		 contains("docker.server.osType", "windows")
+		 contains("system.agent.name", "docker")
+		 contains("system.agent.name", "windows10")
+	}
+	 features {
+		 dockerSupport {
+		 	 cleanupPushedImages = true
+		 	 loginToRegistry = on {
+		 		 dockerRegistryId = "PROJECT_EXT_774"
+		 	 }
+		 }
+	}
 })
 

--- a/.teamcity/generated/PushHubLinux.kts
+++ b/.teamcity/generated/PushHubLinux.kts
@@ -1,203 +1,216 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object push_hub_linux: BuildType(
 {
 name = "Push linux"
 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 steps {
-dockerCommand {
-name = "pull teamcity-server%docker.buildImagePostfix%:EAP-linux"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-server%docker.buildImagePostfix%:EAP-linux"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-server:EAP-linux"
-}
-}
-
-dockerCommand {
-name = "push teamcity-server%docker.buildImagePostfix%:EAP-linux"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-server:EAP-linux
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo %docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo"
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux-arm64"
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-agent:EAP-linux-arm64
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-agent:EAP-linux"
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-agent:EAP-linux
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo %docker.deployRepository%teamcity-agent:EAP-linux-sudo"
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-agent:EAP-linux-sudo
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-linux"
-}
-}
-
-dockerCommand {
-name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-minimal-agent:EAP-linux
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
+	dockerCommand {
+		 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-linux"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-linux"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-server:EAP-linux"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-server%docker.buildImagePostfix%:EAP-linux"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-server:EAP-linux
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo %docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux-arm64"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-agent:EAP-linux-arm64
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-agent:EAP-linux"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-agent:EAP-linux
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo %docker.deployRepository%teamcity-agent:EAP-linux-sudo"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-agent:EAP-linux-sudo
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-linux"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-minimal-agent:EAP-linux
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
 }
 features {
-freeDiskSpace {
-requiredSpace = "6gb"
-failBuild = true
+	freeDiskSpace {
+		 requiredSpace = "6gb"
+		 failBuild = true
+	}
+	dockerSupport {
+		 cleanupPushedImages = true
+		 loginToRegistry = on {
+			 dockerRegistryId = "PROJECT_EXT_774"
+		 }
+	}
+	swabra {
+		 forceCleanCheckout = true
+	}
 }
-dockerSupport {
-cleanupPushedImages = true
-loginToRegistry = on {
-dockerRegistryId = "PROJECT_EXT_774"
-}
-}
-swabra {
-forceCleanCheckout = true
-}
-}
-params {
-param("system.teamcity.agent.ensure.free.space", "6gb")
-}
+	params {
+		 param("system.teamcity.agent.ensure.free.space", "6gb")
+	}
 requirements {
 contains("docker.server.osType", "linux")
 }
-dependencies {
-snapshot(PublishLocal.publish_local)
-{
-onDependencyFailure =  FailureAction.FAIL_TO_START
+	dependencies {
+		 snapshot(PublishLocal.publish_local)
+	{
+ 	 onDependencyFailure =  FailureAction.FAIL_TO_START
 }
-}
+	}
 })
 

--- a/.teamcity/generated/PushHubLinux.kts
+++ b/.teamcity/generated/PushHubLinux.kts
@@ -39,9 +39,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-linux"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-server:EAP-linux"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-server:EAP-linux"
+		}
 	}
 	
 	dockerCommand {
@@ -50,7 +50,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-server:EAP-linux
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -65,9 +65,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo %docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo %docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo"
+		}
 	}
 	
 	dockerCommand {
@@ -76,7 +76,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -91,9 +91,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux-arm64"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux-arm64"
+		}
 	}
 	
 	dockerCommand {
@@ -102,7 +102,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-agent:EAP-linux-arm64
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -117,9 +117,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-agent:EAP-linux"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-agent:EAP-linux"
+		}
 	}
 	
 	dockerCommand {
@@ -128,7 +128,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-agent:EAP-linux
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -143,9 +143,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo %docker.deployRepository%teamcity-agent:EAP-linux-sudo"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo %docker.deployRepository%teamcity-agent:EAP-linux-sudo"
+		}
 	}
 	
 	dockerCommand {
@@ -154,7 +154,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-agent:EAP-linux-sudo
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -169,9 +169,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-linux"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-linux"
+		}
 	}
 	
 	dockerCommand {
@@ -180,7 +180,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-minimal-agent:EAP-linux
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	

--- a/.teamcity/generated/PushHubLinux.kts
+++ b/.teamcity/generated/PushHubLinux.kts
@@ -23,194 +23,193 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object push_hub_linux: BuildType(
-{
-name = "Push linux"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-steps {
-	dockerCommand {
-		 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-linux"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-linux"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-server:EAP-linux"
+object push_hub_linux: BuildType({
+	 name = "Push linux"
+	buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 steps {
+		dockerCommand {
+			 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-linux"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
+			 }
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-server%docker.buildImagePostfix%:EAP-linux"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-server:EAP-linux
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo %docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo"
+		
+		dockerCommand {
+			 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-linux"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-server:EAP-linux"
+			}
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux-arm64"
+		
+		dockerCommand {
+			 name = "push teamcity-server%docker.buildImagePostfix%:EAP-linux"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-server:EAP-linux
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-agent:EAP-linux-arm64
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-agent:EAP-linux"
+		
+		dockerCommand {
+			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+			 }
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-agent:EAP-linux
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo %docker.deployRepository%teamcity-agent:EAP-linux-sudo"
+		
+		dockerCommand {
+			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo %docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo"
+			}
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-agent:EAP-linux-sudo
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-linux"
+		
+		dockerCommand {
+			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-minimal-agent:EAP-linux
-	""".trimIndent()
-			 removeImageAfterPush = false
+		
+		dockerCommand {
+			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+			 }
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux-arm64"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-agent:EAP-linux-arm64
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+			 }
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-agent:EAP-linux"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-agent:EAP-linux
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+			 }
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo %docker.deployRepository%teamcity-agent:EAP-linux-sudo"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-agent:EAP-linux-sudo
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+			 }
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-linux"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-minimal-agent:EAP-linux
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+	 }
+	 features {
+		 freeDiskSpace {
+		 	 requiredSpace = "6gb"
+		 	 failBuild = true
 		 }
-	}
-	
-}
-features {
-	freeDiskSpace {
-		 requiredSpace = "6gb"
-		 failBuild = true
-	}
-	dockerSupport {
-		 cleanupPushedImages = true
-		 loginToRegistry = on {
-			 dockerRegistryId = "PROJECT_EXT_774"
+		 dockerSupport {
+		 	 cleanupPushedImages = true
+		 	 loginToRegistry = on {
+		 		 dockerRegistryId = "PROJECT_EXT_774"
+		 	 }
 		 }
-	}
-	swabra {
-		 forceCleanCheckout = true
-	}
-}
+		 swabra {
+		 	 forceCleanCheckout = true
+		 }
+	 }
 	params {
 		 param("system.teamcity.agent.ensure.free.space", "6gb")
 	}
-requirements {
-contains("docker.server.osType", "linux")
-}
-	dependencies {
-		 snapshot(PublishLocal.publish_local)
-	{
- 	 onDependencyFailure =  FailureAction.FAIL_TO_START
-}
-	}
+	 requirements {
+	 	 contains("docker.server.osType", "linux")
+	 }
+		 dependencies {
+			 snapshot(PublishLocal.publish_local) {
+
+				 onDependencyFailure =  FailureAction.FAIL_TO_START 
+ 		 }
+		 }
 })
 

--- a/.teamcity/generated/PushHubWindows.kts
+++ b/.teamcity/generated/PushHubWindows.kts
@@ -1,257 +1,270 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object push_hub_windows: BuildType(
 {
 name = "Push windows"
 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 steps {
-dockerCommand {
-name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-1809"
-}
-}
-
-dockerCommand {
-name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-server:EAP-nanoserver-1809
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809"
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809"
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-agent:EAP-nanoserver-1809
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809"
-}
-}
-
-dockerCommand {
-name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
-}
-}
-
-dockerCommand {
-name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-server:EAP-nanoserver-2004
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-agent:EAP-nanoserver-2004
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-commandType = other {
-subCommand = "pull"
-commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-commandType = other {
-subCommand = "tag"
-commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
-}
-}
-
-dockerCommand {
-name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-commandType = push {
-namesAndTags = """
-%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
+	dockerCommand {
+		 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-1809"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-server:EAP-nanoserver-1809
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-agent:EAP-nanoserver-1809
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-server:EAP-nanoserver-2004
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-agent:EAP-nanoserver-2004
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
 }
 features {
-freeDiskSpace {
-requiredSpace = "52gb"
-failBuild = true
+	freeDiskSpace {
+		 requiredSpace = "52gb"
+		 failBuild = true
+	}
+	dockerSupport {
+		 cleanupPushedImages = true
+		 loginToRegistry = on {
+			 dockerRegistryId = "PROJECT_EXT_774"
+		 }
+	}
+	swabra {
+		 forceCleanCheckout = true
+	}
 }
-dockerSupport {
-cleanupPushedImages = true
-loginToRegistry = on {
-dockerRegistryId = "PROJECT_EXT_774"
-}
-}
-swabra {
-forceCleanCheckout = true
-}
-}
-params {
-param("system.teamcity.agent.ensure.free.space", "52gb")
-}
+	params {
+		 param("system.teamcity.agent.ensure.free.space", "52gb")
+	}
 requirements {
 contains("docker.server.osType", "windows")
 contains("system.agent.name", "docker")
 contains("system.agent.name", "windows10")
 }
-dependencies {
-snapshot(PublishLocal.publish_local)
-{
-onDependencyFailure =  FailureAction.FAIL_TO_START
+	dependencies {
+		 snapshot(PublishLocal.publish_local)
+	{
+ 	 onDependencyFailure =  FailureAction.FAIL_TO_START
 }
-}
+	}
 })
 

--- a/.teamcity/generated/PushHubWindows.kts
+++ b/.teamcity/generated/PushHubWindows.kts
@@ -39,9 +39,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-1809"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-1809"
+		}
 	}
 	
 	dockerCommand {
@@ -50,7 +50,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-server:EAP-nanoserver-1809
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -65,9 +65,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809"
+		}
 	}
 	
 	dockerCommand {
@@ -76,7 +76,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -91,9 +91,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809"
+		}
 	}
 	
 	dockerCommand {
@@ -102,7 +102,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-agent:EAP-nanoserver-1809
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -117,9 +117,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809"
+		}
 	}
 	
 	dockerCommand {
@@ -128,7 +128,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -143,9 +143,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
+		}
 	}
 	
 	dockerCommand {
@@ -154,7 +154,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-server:EAP-nanoserver-2004
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -169,9 +169,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
+		}
 	}
 	
 	dockerCommand {
@@ -180,7 +180,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -195,9 +195,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
+		}
 	}
 	
 	dockerCommand {
@@ -206,7 +206,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-agent:EAP-nanoserver-2004
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -221,9 +221,9 @@ steps {
 	dockerCommand {
 		 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
-	}
+			 subCommand = "tag"
+			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
+		}
 	}
 	
 	dockerCommand {
@@ -232,7 +232,7 @@ steps {
 			 namesAndTags = """
 	%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	

--- a/.teamcity/generated/PushHubWindows.kts
+++ b/.teamcity/generated/PushHubWindows.kts
@@ -23,248 +23,247 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object push_hub_windows: BuildType(
-{
-name = "Push windows"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-steps {
-	dockerCommand {
-		 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-1809"
+object push_hub_windows: BuildType({
+	 name = "Push windows"
+	buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 steps {
+		dockerCommand {
+			 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 }
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-server:EAP-nanoserver-1809
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809"
+		
+		dockerCommand {
+			 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-1809"
+			}
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809"
+		
+		dockerCommand {
+			 name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-server:EAP-nanoserver-1809
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-agent:EAP-nanoserver-1809
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809"
+		
+		dockerCommand {
+			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+			 }
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
+		
+		dockerCommand {
+			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809"
+			}
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-server:EAP-nanoserver-2004
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
+		
+		dockerCommand {
+			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
+		
+		dockerCommand {
+			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 }
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-agent:EAP-nanoserver-2004
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
+		
+		dockerCommand {
+			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809"
+			}
 		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004
-	""".trimIndent()
-			 removeImageAfterPush = false
+		
+		dockerCommand {
+			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-agent:EAP-nanoserver-1809
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 }
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 }
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-server:EAP-nanoserver-2004
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+			 }
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 }
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-agent:EAP-nanoserver-2004
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 }
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+	 }
+	 features {
+		 freeDiskSpace {
+		 	 requiredSpace = "52gb"
+		 	 failBuild = true
 		 }
-	}
-	
-}
-features {
-	freeDiskSpace {
-		 requiredSpace = "52gb"
-		 failBuild = true
-	}
-	dockerSupport {
-		 cleanupPushedImages = true
-		 loginToRegistry = on {
-			 dockerRegistryId = "PROJECT_EXT_774"
+		 dockerSupport {
+		 	 cleanupPushedImages = true
+		 	 loginToRegistry = on {
+		 		 dockerRegistryId = "PROJECT_EXT_774"
+		 	 }
 		 }
-	}
-	swabra {
-		 forceCleanCheckout = true
-	}
-}
+		 swabra {
+		 	 forceCleanCheckout = true
+		 }
+	 }
 	params {
 		 param("system.teamcity.agent.ensure.free.space", "52gb")
 	}
-requirements {
-contains("docker.server.osType", "windows")
-contains("system.agent.name", "docker")
-contains("system.agent.name", "windows10")
-}
-	dependencies {
-		 snapshot(PublishLocal.publish_local)
-	{
- 	 onDependencyFailure =  FailureAction.FAIL_TO_START
-}
-	}
+	 requirements {
+	 	 contains("docker.server.osType", "windows")
+	 	 contains("system.agent.name", "docker")
+	 	 contains("system.agent.name", "windows10")
+	 }
+		 dependencies {
+			 snapshot(PublishLocal.publish_local) {
+
+				 onDependencyFailure =  FailureAction.FAIL_TO_START 
+ 		 }
+		 }
 })
 

--- a/.teamcity/generated/PushLocalLinux1804.kts
+++ b/.teamcity/generated/PushLocalLinux1804.kts
@@ -23,7 +23,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-	 object push_local_linux_18_04 : BuildType({
+object push_local_linux_18_04 : BuildType({
 	 name = "ON PAUSE Build and push linux 18.04"
 	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 	 description  = "teamcity-server:EAP-linux-arm64-18.04,EAP:EAP-linux-18.04,EAP teamcity-minimal-agent:EAP-linux-arm64-18.04,EAP:EAP-linux-18.04,EAP teamcity-agent:EAP-linux-arm64-18.04,EAP:EAP-linux-arm64-18.04-sudo:EAP-linux-18.04,EAP:EAP-linux-18.04-sudo"

--- a/.teamcity/generated/PushLocalLinux1804.kts
+++ b/.teamcity/generated/PushLocalLinux1804.kts
@@ -1,18 +1,31 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object push_local_linux_18_04 : BuildType({
-name = "ON PAUSE Build and push linux 18.04"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-description  = "teamcity-server:EAP-linux-arm64-18.04,EAP:EAP-linux-18.04,EAP teamcity-minimal-agent:EAP-linux-arm64-18.04,EAP:EAP-linux-18.04,EAP teamcity-agent:EAP-linux-arm64-18.04,EAP:EAP-linux-arm64-18.04-sudo:EAP-linux-18.04,EAP:EAP-linux-18.04-sudo"
+	 object push_local_linux_18_04 : BuildType({
+	 name = "ON PAUSE Build and push linux 18.04"
+	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 description  = "teamcity-server:EAP-linux-arm64-18.04,EAP:EAP-linux-18.04,EAP teamcity-minimal-agent:EAP-linux-arm64-18.04,EAP:EAP-linux-18.04,EAP teamcity-agent:EAP-linux-arm64-18.04,EAP:EAP-linux-arm64-18.04-sudo:EAP-linux-18.04,EAP:EAP-linux-18.04-sudo"
 })
 

--- a/.teamcity/generated/PushLocalLinux2004.kts
+++ b/.teamcity/generated/PushLocalLinux2004.kts
@@ -1,349 +1,325 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object push_local_linux_20_04 : BuildType({
-name = "Build and push linux 20.04"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-description  = "teamcity-server:EAP-linux,EAP teamcity-minimal-agent:EAP-linux,EAP teamcity-agent:EAP-linux,EAP:EAP-linux-sudo:EAP-linux-arm64,EAP:EAP-linux-arm64-sudo"
-vcs {root(TeamCityDockerImagesRepo)}
-steps {
-dockerCommand {
-name = "pull ubuntu:20.04"
-commandType = other {
-subCommand = "pull"
-commandArgs = "ubuntu:20.04"
-}
-}
+	 object push_local_linux_20_04 : BuildType({
+	 name = "Build and push linux 20.04"
+	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 description  = "teamcity-server:EAP-linux,EAP teamcity-minimal-agent:EAP-linux,EAP teamcity-agent:EAP-linux,EAP:EAP-linux-sudo:EAP-linux-arm64,EAP:EAP-linux-arm64-sudo"
+	 vcs {
+		 root(TeamCityDockerImagesRepo)
+	 }
 
-script {
-name = "context teamcity-server:EAP-linux"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity/buildAgent >> context/.dockerignore
-echo TeamCity/temp >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-server:EAP-linux"
-commandType = build {
-source = file {
-path = """context/generated/linux/Server/Ubuntu/20.04/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-server:EAP-linux
-""".trimIndent()
-}
-param("dockerImage.platform", "linux")
-}
-
-script {
-name = "context teamcity-minimal-agent:EAP-linux"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity/webapps >> context/.dockerignore
-echo TeamCity/devPackage >> context/.dockerignore
-echo TeamCity/lib >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-minimal-agent:EAP-linux"
-commandType = build {
-source = file {
-path = """context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-minimal-agent:EAP-linux
-""".trimIndent()
-}
-param("dockerImage.platform", "linux")
-}
-
-script {
-name = "context teamcity-agent:EAP-linux"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-agent:EAP-linux"
-commandType = build {
-source = file {
-path = """context/generated/linux/Agent/Ubuntu/20.04/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-agent:EAP-linux
-""".trimIndent()
-}
-param("dockerImage.platform", "linux")
-}
-
-script {
-name = "context teamcity-agent:EAP-linux-sudo"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-agent:EAP-linux-sudo"
-commandType = build {
-source = file {
-path = """context/generated/linux/Agent/Ubuntu/20.04-sudo/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-agent:EAP-linux-sudo
-""".trimIndent()
-}
-param("dockerImage.platform", "linux")
-}
-
-//script {
-//name = "context teamcity-agent:EAP-linux-arm64"
-//scriptContent = """
-//echo 2> context/.dockerignore
-//echo TeamCity >> context/.dockerignore
-//""".trimIndent()
-//}
-
-//dockerCommand {
-//name = "build teamcity-agent:EAP-linux-arm64"
-//commandType = build {
-//source = file {
-//path = """context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile"""
-//}
-//contextDir = "context"
-//commandArgs = "--no-cache"
-//namesAndTags = """
-//teamcity-agent:EAP-linux-arm64
-//""".trimIndent()
-//}
-//param("dockerImage.platform", "linux")
-//}
-//
-//script {
-//name = "context teamcity-agent:EAP-linux-arm64-sudo"
-//scriptContent = """
-//echo 2> context/.dockerignore
-//echo TeamCity >> context/.dockerignore
-//""".trimIndent()
-//}
-//
-//dockerCommand {
-//name = "build teamcity-agent:EAP-linux-arm64-sudo"
-//commandType = build {
-//source = file {
-//path = """context/generated/linux/Agent/UbuntuARM/20.04-sudo/Dockerfile"""
-//}
-//contextDir = "context"
-//commandArgs = "--no-cache"
-//namesAndTags = """
-//teamcity-agent:EAP-linux-arm64-sudo
-//""".trimIndent()
-//}
-//param("dockerImage.platform", "linux")
-//}
-
-dockerCommand {
-name = "tag teamcity-server:EAP-linux"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-server:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-minimal-agent:EAP-linux"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-minimal-agent:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent:EAP-linux"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-agent:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent:EAP-linux-sudo"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-agent:EAP-linux-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-}
-}
-
-//dockerCommand {
-//name = "tag teamcity-agent:EAP-linux-arm64"
-//commandType = other {
-//subCommand = "tag"
-//commandArgs = "teamcity-agent:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-//}
-//}
-
-//dockerCommand {
-//name = "tag teamcity-agent:EAP-linux-arm64-sudo"
-//commandType = other {
-//subCommand = "tag"
-//commandArgs = "teamcity-agent:EAP-linux-arm64-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-//}
-//}
-
-dockerCommand {
-name = "push teamcity-server:EAP-linux"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "push teamcity-minimal-agent:EAP-linux"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent:EAP-linux"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent:EAP-linux-sudo"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-//dockerCommand {
-//name = "push teamcity-agent:EAP-linux-arm64"
-//commandType = push {
-//namesAndTags = """
-//%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64
-//""".trimIndent()
-//removeImageAfterPush = false
-//}
-//}
-
-//dockerCommand {
-//name = "push teamcity-agent:EAP-linux-arm64-sudo"
-//commandType = push {
-//namesAndTags = """
-//%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo
-//""".trimIndent()
-//removeImageAfterPush = false
-//}
-//}
-    // NOTE: The following steps are experimental identification of an EAP TeamCity agent Docker image
-    dockerCommand {
-        name = "Identify EAP TeamCity Agent Image - Linux-sudo"
-
-        commandType = other {
-            subCommand = "tag"
-            commandArgs = "teamcity-agent:EAP-linux-sudo %docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:%dockerImage.teamcity.buildNumber%-%build.counter%-linux-sudo"
-        }
-    }
-
-    dockerCommand {
-        name = "Push identified EAP TeamCity Agent Image - Linux-sudo"
-        commandType = push {
-            namesAndTags = """
-%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:%dockerImage.teamcity.buildNumber%-%build.counter%-linux-sudo
-""".trimIndent()
-            removeImageAfterPush = false
-        }
-    }
-
-    dockerCommand {
-        name = "Identify EAP TeamCity Agent Image"
-
-        commandType = other {
-            subCommand = "tag"
-            commandArgs = "teamcity-agent:EAP-linux %docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:%dockerImage.teamcity.buildNumber%-%build.counter%-linux"
-        }
-    }
-
-    dockerCommand {
-        name = "Push identified EAP TeamCity Agent Image"
-        commandType = push {
-            namesAndTags = """
-%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:%dockerImage.teamcity.buildNumber%-%build.counter%-linux
-""".trimIndent()
-            removeImageAfterPush = false
-        }
-    }
-
+ steps {
+	dockerCommand {
+		 name = "pull ubuntu:20.04"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "ubuntu:20.04"
+		 }
+	}
+	
+	script {
+		 name = "context teamcity-server:EAP-linux"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity/buildAgent >> context/.dockerignore
+	echo TeamCity/temp >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-server:EAP-linux"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/linux/Server/Ubuntu/20.04/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-server:EAP-linux
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "linux")
+	}
+	
+	script {
+		 name = "context teamcity-minimal-agent:EAP-linux"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity/webapps >> context/.dockerignore
+	echo TeamCity/devPackage >> context/.dockerignore
+	echo TeamCity/lib >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-minimal-agent:EAP-linux"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-minimal-agent:EAP-linux
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "linux")
+	}
+	
+	script {
+		 name = "context teamcity-agent:EAP-linux"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-agent:EAP-linux"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/linux/Agent/Ubuntu/20.04/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-agent:EAP-linux
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "linux")
+	}
+	
+	script {
+		 name = "context teamcity-agent:EAP-linux-sudo"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-agent:EAP-linux-sudo"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/linux/Agent/Ubuntu/20.04-sudo/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-agent:EAP-linux-sudo
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "linux")
+	}
+	
+	script {
+		 name = "context teamcity-agent:EAP-linux-arm64"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-agent:EAP-linux-arm64"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-agent:EAP-linux-arm64
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "linux")
+	}
+	
+	script {
+		 name = "context teamcity-agent:EAP-linux-arm64-sudo"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-agent:EAP-linux-arm64-sudo"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/linux/Agent/UbuntuARM/20.04-sudo/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-agent:EAP-linux-arm64-sudo
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "linux")
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-server:EAP-linux"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-server:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-minimal-agent:EAP-linux"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-minimal-agent:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent:EAP-linux"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-agent:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent:EAP-linux-sudo"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-agent:EAP-linux-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent:EAP-linux-arm64"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-agent:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent:EAP-linux-arm64-sudo"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-agent:EAP-linux-arm64-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-server:EAP-linux"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-minimal-agent:EAP-linux"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent:EAP-linux"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent:EAP-linux-sudo"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent:EAP-linux-arm64"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent:EAP-linux-arm64-sudo"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
 }
 features {
-freeDiskSpace {
-requiredSpace = "8gb"
-failBuild = true
+	freeDiskSpace {
+		 requiredSpace = "8gb"
+		 failBuild = true
+	}
+	dockerSupport {
+		 cleanupPushedImages = true
+		 loginToRegistry = on {
+			 dockerRegistryId = "PROJECT_EXT_774"
+		 }
+	}
+	swabra {
+		 forceCleanCheckout = true
+	}
 }
-
-
-dockerSupport {
-    cleanupPushedImages = true
-    loginToRegistry = on {
-        dockerRegistryId = "PROJECT_EXT_774,PROJECT_EXT_315"
-    }
-}
-
-
-        swabra {
-forceCleanCheckout = true
-}
-}
-dependencies {
-dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
-snapshot { onDependencyFailure = FailureAction.IGNORE
-reuseBuilds = ReuseBuilds.ANY }
-artifacts {
-artifactRules = "TeamCity.zip!/**=>context/TeamCity"
-}
-}
-}
-params {
-param("system.teamcity.agent.ensure.free.space", "8gb")
-}
-requirements {
-}
+	dependencies {
+		 dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
+			 snapshot {
+				 onDependencyFailure = FailureAction.IGNORE
+				 reuseBuilds = ReuseBuilds.ANY
+			 }
+			 artifacts {
+				 artifactRules = "TeamCity.zip!/**=>context/TeamCity"
+			 }
+		 }
+	}
+	params {
+		 param("system.teamcity.agent.ensure.free.space", "8gb")
+	}
+	requirements {
+	}
 })
 

--- a/.teamcity/generated/PushLocalLinux2004.kts
+++ b/.teamcity/generated/PushLocalLinux2004.kts
@@ -184,49 +184,49 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 	dockerCommand {
 		 name = "tag teamcity-server:EAP-linux"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-server:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-server:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-minimal-agent:EAP-linux"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-minimal-agent:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-minimal-agent:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-agent:EAP-linux"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-agent:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-agent:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-agent:EAP-linux-sudo"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-agent:EAP-linux-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-agent:EAP-linux-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-agent:EAP-linux-arm64"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-agent:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-agent:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-agent:EAP-linux-arm64-sudo"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-agent:EAP-linux-arm64-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-agent:EAP-linux-arm64-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+		}
 	}
 	
 	dockerCommand {
@@ -235,7 +235,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -245,7 +245,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -255,7 +255,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -265,7 +265,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -275,7 +275,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -285,7 +285,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	

--- a/.teamcity/generated/PushLocalLinux2004.kts
+++ b/.teamcity/generated/PushLocalLinux2004.kts
@@ -23,7 +23,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-	 object push_local_linux_20_04 : BuildType({
+object push_local_linux_20_04 : BuildType({
 	 name = "Build and push linux 20.04"
 	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 	 description  = "teamcity-server:EAP-linux,EAP teamcity-minimal-agent:EAP-linux,EAP teamcity-agent:EAP-linux,EAP:EAP-linux-sudo:EAP-linux-arm64,EAP:EAP-linux-arm64-sudo"
@@ -31,280 +31,280 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 		 root(TeamCityDockerImagesRepo)
 	 }
 
- steps {
-	dockerCommand {
-		 name = "pull ubuntu:20.04"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "ubuntu:20.04"
-		 }
-	}
-	
-	script {
-		 name = "context teamcity-server:EAP-linux"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity/buildAgent >> context/.dockerignore
-	echo TeamCity/temp >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-server:EAP-linux"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/linux/Server/Ubuntu/20.04/Dockerfile"""
+ 	 steps {
+		dockerCommand {
+			 name = "pull ubuntu:20.04"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "ubuntu:20.04"
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-server:EAP-linux
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "linux")
-	}
-	
-	script {
-		 name = "context teamcity-minimal-agent:EAP-linux"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity/webapps >> context/.dockerignore
-	echo TeamCity/devPackage >> context/.dockerignore
-	echo TeamCity/lib >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-minimal-agent:EAP-linux"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile"""
+		}
+		
+		script {
+			 name = "context teamcity-server:EAP-linux"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity/buildAgent >> context/.dockerignore
+		echo TeamCity/temp >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-server:EAP-linux"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/linux/Server/Ubuntu/20.04/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-server:EAP-linux
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		script {
+			 name = "context teamcity-minimal-agent:EAP-linux"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity/webapps >> context/.dockerignore
+		echo TeamCity/devPackage >> context/.dockerignore
+		echo TeamCity/lib >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-minimal-agent:EAP-linux"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-minimal-agent:EAP-linux
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		script {
+			 name = "context teamcity-agent:EAP-linux"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-agent:EAP-linux"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/linux/Agent/Ubuntu/20.04/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-agent:EAP-linux
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		script {
+			 name = "context teamcity-agent:EAP-linux-sudo"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-agent:EAP-linux-sudo"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/linux/Agent/Ubuntu/20.04-sudo/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-agent:EAP-linux-sudo
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		script {
+			 name = "context teamcity-agent:EAP-linux-arm64"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-agent:EAP-linux-arm64"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-agent:EAP-linux-arm64
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		script {
+			 name = "context teamcity-agent:EAP-linux-arm64-sudo"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-agent:EAP-linux-arm64-sudo"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/linux/Agent/UbuntuARM/20.04-sudo/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-agent:EAP-linux-arm64-sudo
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-server:EAP-linux"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-server:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-minimal-agent:EAP-linux"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-minimal-agent:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent:EAP-linux"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent:EAP-linux-sudo"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-linux-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent:EAP-linux-arm64"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent:EAP-linux-arm64-sudo"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-linux-arm64-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-server:EAP-linux"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux
+		""".trimIndent()
+				 removeImageAfterPush = false
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-minimal-agent:EAP-linux
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "linux")
-	}
-	
-	script {
-		 name = "context teamcity-agent:EAP-linux"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-agent:EAP-linux"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/linux/Agent/Ubuntu/20.04/Dockerfile"""
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-minimal-agent:EAP-linux"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux
+		""".trimIndent()
+				 removeImageAfterPush = false
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-agent:EAP-linux
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "linux")
-	}
-	
-	script {
-		 name = "context teamcity-agent:EAP-linux-sudo"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-agent:EAP-linux-sudo"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/linux/Agent/Ubuntu/20.04-sudo/Dockerfile"""
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent:EAP-linux"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux
+		""".trimIndent()
+				 removeImageAfterPush = false
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-agent:EAP-linux-sudo
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "linux")
-	}
-	
-	script {
-		 name = "context teamcity-agent:EAP-linux-arm64"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-agent:EAP-linux-arm64"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile"""
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent:EAP-linux-sudo"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo
+		""".trimIndent()
+				 removeImageAfterPush = false
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-agent:EAP-linux-arm64
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "linux")
-	}
-	
-	script {
-		 name = "context teamcity-agent:EAP-linux-arm64-sudo"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-agent:EAP-linux-arm64-sudo"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/linux/Agent/UbuntuARM/20.04-sudo/Dockerfile"""
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent:EAP-linux-arm64"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64
+		""".trimIndent()
+				 removeImageAfterPush = false
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-agent:EAP-linux-arm64-sudo
-	""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent:EAP-linux-arm64-sudo"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
 	}
-	param("dockerImage.platform", "linux")
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-server:EAP-linux"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-server:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
+	features {
+		freeDiskSpace {
+			 requiredSpace = "8gb"
+			 failBuild = true
+		}
+		dockerSupport {
+			 cleanupPushedImages = true
+			 loginToRegistry = on {
+				 dockerRegistryId = "PROJECT_EXT_774"
+			 }
+		}
+		swabra {
+			 forceCleanCheckout = true
 		}
 	}
-	
-	dockerCommand {
-		 name = "tag teamcity-minimal-agent:EAP-linux"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-minimal-agent:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-		}
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent:EAP-linux"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-agent:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-		}
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent:EAP-linux-sudo"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-agent:EAP-linux-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-		}
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent:EAP-linux-arm64"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-agent:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-		}
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent:EAP-linux-arm64-sudo"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-agent:EAP-linux-arm64-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-server:EAP-linux"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-minimal-agent:EAP-linux"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent:EAP-linux"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent:EAP-linux-sudo"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent:EAP-linux-arm64"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent:EAP-linux-arm64-sudo"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-}
-features {
-	freeDiskSpace {
-		 requiredSpace = "8gb"
-		 failBuild = true
-	}
-	dockerSupport {
-		 cleanupPushedImages = true
-		 loginToRegistry = on {
-			 dockerRegistryId = "PROJECT_EXT_774"
-		 }
-	}
-	swabra {
-		 forceCleanCheckout = true
-	}
-}
 	dependencies {
 		 dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
 			 snapshot {

--- a/.teamcity/generated/PushLocalWindows1803.kts
+++ b/.teamcity/generated/PushLocalWindows1803.kts
@@ -23,7 +23,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-	 object push_local_windows_1803 : BuildType({
+object push_local_windows_1803 : BuildType({
 	 name = "ON PAUSE Build and push windows 1803"
 	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 	 description  = "teamcity-server:EAP-nanoserver-1803,EAP teamcity-minimal-agent:EAP-nanoserver-1803,EAP teamcity-agent:EAP-windowsservercore-1803,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1803,EAP"

--- a/.teamcity/generated/PushLocalWindows1803.kts
+++ b/.teamcity/generated/PushLocalWindows1803.kts
@@ -1,18 +1,31 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object push_local_windows_1803 : BuildType({
-name = "ON PAUSE Build and push windows 1803"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-description  = "teamcity-server:EAP-nanoserver-1803,EAP teamcity-minimal-agent:EAP-nanoserver-1803,EAP teamcity-agent:EAP-windowsservercore-1803,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1803,EAP"
+	 object push_local_windows_1803 : BuildType({
+	 name = "ON PAUSE Build and push windows 1803"
+	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 description  = "teamcity-server:EAP-nanoserver-1803,EAP teamcity-minimal-agent:EAP-nanoserver-1803,EAP teamcity-agent:EAP-windowsservercore-1803,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1803,EAP"
 })
 

--- a/.teamcity/generated/PushLocalWindows1809.kts
+++ b/.teamcity/generated/PushLocalWindows1809.kts
@@ -158,33 +158,33 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 	dockerCommand {
 		 name = "tag teamcity-server:EAP-nanoserver-1809"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-server:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-server:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-minimal-agent:EAP-nanoserver-1809"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-agent:EAP-windowsservercore-1809"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-agent:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-agent:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-agent:EAP-nanoserver-1809"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+		}
 	}
 	
 	dockerCommand {
@@ -193,7 +193,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -203,7 +203,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -213,7 +213,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -223,7 +223,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	

--- a/.teamcity/generated/PushLocalWindows1809.kts
+++ b/.teamcity/generated/PushLocalWindows1809.kts
@@ -1,247 +1,265 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object push_local_windows_1809 : BuildType({
-name = "Build and push windows 1809"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-description  = "teamcity-server:EAP-nanoserver-1809,EAP teamcity-minimal-agent:EAP-nanoserver-1809,EAP teamcity-agent:EAP-windowsservercore-1809,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1809,EAP"
-vcs {root(TeamCityDockerImagesRepo)}
-steps {
-dockerCommand {
-name = "pull mcr.microsoft.com/powershell:nanoserver-1809"
-commandType = other {
-subCommand = "pull"
-commandArgs = "mcr.microsoft.com/powershell:nanoserver-1809"
-}
-}
+	 object push_local_windows_1809 : BuildType({
+	 name = "Build and push windows 1809"
+	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 description  = "teamcity-server:EAP-nanoserver-1809,EAP teamcity-minimal-agent:EAP-nanoserver-1809,EAP teamcity-agent:EAP-windowsservercore-1809,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1809,EAP"
+	 vcs {
+		 root(TeamCityDockerImagesRepo)
+	 }
 
-dockerCommand {
-name = "pull mcr.microsoft.com/windows/nanoserver:1809"
-commandType = other {
-subCommand = "pull"
-commandArgs = "mcr.microsoft.com/windows/nanoserver:1809"
-}
-}
-
-dockerCommand {
-name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
-commandType = other {
-subCommand = "pull"
-commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
-}
-}
-
-script {
-name = "context teamcity-server:EAP-nanoserver-1809"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity/buildAgent >> context/.dockerignore
-echo TeamCity/temp >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-server:EAP-nanoserver-1809"
-commandType = build {
-source = file {
-path = """context/generated/windows/Server/nanoserver/1809/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-server:EAP-nanoserver-1809
-""".trimIndent()
-}
-param("dockerImage.platform", "windows")
-}
-
-script {
-name = "context teamcity-minimal-agent:EAP-nanoserver-1809"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity/webapps >> context/.dockerignore
-echo TeamCity/devPackage >> context/.dockerignore
-echo TeamCity/lib >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-minimal-agent:EAP-nanoserver-1809"
-commandType = build {
-source = file {
-path = """context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-minimal-agent:EAP-nanoserver-1809
-""".trimIndent()
-}
-param("dockerImage.platform", "windows")
-}
-
-script {
-name = "context teamcity-agent:EAP-windowsservercore-1809"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity/webapps >> context/.dockerignore
-echo TeamCity/devPackage >> context/.dockerignore
-echo TeamCity/lib >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-agent:EAP-windowsservercore-1809"
-commandType = build {
-source = file {
-path = """context/generated/windows/Agent/windowsservercore/1809/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-agent:EAP-windowsservercore-1809
-""".trimIndent()
-}
-param("dockerImage.platform", "windows")
-}
-
-script {
-name = "context teamcity-agent:EAP-nanoserver-1809"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity/webapps >> context/.dockerignore
-echo TeamCity/devPackage >> context/.dockerignore
-echo TeamCity/lib >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-agent:EAP-nanoserver-1809"
-commandType = build {
-source = file {
-path = """context/generated/windows/Agent/nanoserver/1809/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-agent:EAP-nanoserver-1809
-""".trimIndent()
-}
-param("dockerImage.platform", "windows")
-}
-
-dockerCommand {
-name = "tag teamcity-server:EAP-nanoserver-1809"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-server:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-minimal-agent:EAP-nanoserver-1809"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-minimal-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent:EAP-windowsservercore-1809"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-agent:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent:EAP-nanoserver-1809"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-}
-}
-
-dockerCommand {
-name = "push teamcity-server:EAP-nanoserver-1809"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "push teamcity-minimal-agent:EAP-nanoserver-1809"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent:EAP-windowsservercore-1809"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent:EAP-nanoserver-1809"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
+ steps {
+	dockerCommand {
+		 name = "pull mcr.microsoft.com/powershell:nanoserver-1809"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "mcr.microsoft.com/powershell:nanoserver-1809"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull mcr.microsoft.com/windows/nanoserver:1809"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "mcr.microsoft.com/windows/nanoserver:1809"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
+		 }
+	}
+	
+	script {
+		 name = "context teamcity-server:EAP-nanoserver-1809"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity/buildAgent >> context/.dockerignore
+	echo TeamCity/temp >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-server:EAP-nanoserver-1809"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/windows/Server/nanoserver/1809/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-server:EAP-nanoserver-1809
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "windows")
+	}
+	
+	script {
+		 name = "context teamcity-minimal-agent:EAP-nanoserver-1809"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity/webapps >> context/.dockerignore
+	echo TeamCity/devPackage >> context/.dockerignore
+	echo TeamCity/lib >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-minimal-agent:EAP-nanoserver-1809"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-minimal-agent:EAP-nanoserver-1809
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "windows")
+	}
+	
+	script {
+		 name = "context teamcity-agent:EAP-windowsservercore-1809"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity/webapps >> context/.dockerignore
+	echo TeamCity/devPackage >> context/.dockerignore
+	echo TeamCity/lib >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-agent:EAP-windowsservercore-1809"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/windows/Agent/windowsservercore/1809/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-agent:EAP-windowsservercore-1809
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "windows")
+	}
+	
+	script {
+		 name = "context teamcity-agent:EAP-nanoserver-1809"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity/webapps >> context/.dockerignore
+	echo TeamCity/devPackage >> context/.dockerignore
+	echo TeamCity/lib >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-agent:EAP-nanoserver-1809"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/windows/Agent/nanoserver/1809/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-agent:EAP-nanoserver-1809
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "windows")
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-server:EAP-nanoserver-1809"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-server:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-minimal-agent:EAP-nanoserver-1809"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent:EAP-windowsservercore-1809"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-agent:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent:EAP-nanoserver-1809"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-server:EAP-nanoserver-1809"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-minimal-agent:EAP-nanoserver-1809"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent:EAP-windowsservercore-1809"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent:EAP-nanoserver-1809"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
 }
 features {
-freeDiskSpace {
-requiredSpace = "43gb"
-failBuild = true
+	freeDiskSpace {
+		 requiredSpace = "43gb"
+		 failBuild = true
+	}
+	dockerSupport {
+		 cleanupPushedImages = true
+		 loginToRegistry = on {
+			 dockerRegistryId = "PROJECT_EXT_774"
+		 }
+	}
+	swabra {
+		 forceCleanCheckout = true
+	}
 }
-dockerSupport {
-cleanupPushedImages = true
-loginToRegistry = on {
-dockerRegistryId = "PROJECT_EXT_774"
-}
-}
-swabra {
-forceCleanCheckout = true
-}
-}
-dependencies {
-dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
-snapshot { onDependencyFailure = FailureAction.IGNORE
-reuseBuilds = ReuseBuilds.ANY }
-artifacts {
-artifactRules = "TeamCity.zip!/**=>context/TeamCity"
-}
-}
-}
-params {
-param("system.teamcity.agent.ensure.free.space", "43gb")
-}
-requirements {
-contains("system.agent.name", "docker")
-contains("system.agent.name", "windows10")
-}
+	dependencies {
+		 dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
+			 snapshot {
+				 onDependencyFailure = FailureAction.IGNORE
+				 reuseBuilds = ReuseBuilds.ANY
+			 }
+			 artifacts {
+				 artifactRules = "TeamCity.zip!/**=>context/TeamCity"
+			 }
+		 }
+	}
+	params {
+		 param("system.teamcity.agent.ensure.free.space", "43gb")
+	}
+	requirements {
+	contains("system.agent.name", "docker")
+	contains("system.agent.name", "windows10")
+	}
 })
 

--- a/.teamcity/generated/PushLocalWindows1809.kts
+++ b/.teamcity/generated/PushLocalWindows1809.kts
@@ -23,7 +23,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-	 object push_local_windows_1809 : BuildType({
+object push_local_windows_1809 : BuildType({
 	 name = "Build and push windows 1809"
 	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 	 description  = "teamcity-server:EAP-nanoserver-1809,EAP teamcity-minimal-agent:EAP-nanoserver-1809,EAP teamcity-agent:EAP-windowsservercore-1809,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1809,EAP"
@@ -31,218 +31,218 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 		 root(TeamCityDockerImagesRepo)
 	 }
 
- steps {
-	dockerCommand {
-		 name = "pull mcr.microsoft.com/powershell:nanoserver-1809"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "mcr.microsoft.com/powershell:nanoserver-1809"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull mcr.microsoft.com/windows/nanoserver:1809"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "mcr.microsoft.com/windows/nanoserver:1809"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
-		 }
-	}
-	
-	script {
-		 name = "context teamcity-server:EAP-nanoserver-1809"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity/buildAgent >> context/.dockerignore
-	echo TeamCity/temp >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-server:EAP-nanoserver-1809"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/windows/Server/nanoserver/1809/Dockerfile"""
+ 	 steps {
+		dockerCommand {
+			 name = "pull mcr.microsoft.com/powershell:nanoserver-1809"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "mcr.microsoft.com/powershell:nanoserver-1809"
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-server:EAP-nanoserver-1809
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "windows")
-	}
-	
-	script {
-		 name = "context teamcity-minimal-agent:EAP-nanoserver-1809"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity/webapps >> context/.dockerignore
-	echo TeamCity/devPackage >> context/.dockerignore
-	echo TeamCity/lib >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-minimal-agent:EAP-nanoserver-1809"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile"""
+		}
+		
+		dockerCommand {
+			 name = "pull mcr.microsoft.com/windows/nanoserver:1809"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "mcr.microsoft.com/windows/nanoserver:1809"
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-minimal-agent:EAP-nanoserver-1809
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "windows")
-	}
-	
-	script {
-		 name = "context teamcity-agent:EAP-windowsservercore-1809"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity/webapps >> context/.dockerignore
-	echo TeamCity/devPackage >> context/.dockerignore
-	echo TeamCity/lib >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-agent:EAP-windowsservercore-1809"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/windows/Agent/windowsservercore/1809/Dockerfile"""
+		}
+		
+		dockerCommand {
+			 name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-agent:EAP-windowsservercore-1809
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "windows")
-	}
-	
-	script {
-		 name = "context teamcity-agent:EAP-nanoserver-1809"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity/webapps >> context/.dockerignore
-	echo TeamCity/devPackage >> context/.dockerignore
-	echo TeamCity/lib >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-agent:EAP-nanoserver-1809"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/windows/Agent/nanoserver/1809/Dockerfile"""
+		}
+		
+		script {
+			 name = "context teamcity-server:EAP-nanoserver-1809"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity/buildAgent >> context/.dockerignore
+		echo TeamCity/temp >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-server:EAP-nanoserver-1809"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/windows/Server/nanoserver/1809/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-server:EAP-nanoserver-1809
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "windows")
+		}
+		
+		script {
+			 name = "context teamcity-minimal-agent:EAP-nanoserver-1809"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity/webapps >> context/.dockerignore
+		echo TeamCity/devPackage >> context/.dockerignore
+		echo TeamCity/lib >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-minimal-agent:EAP-nanoserver-1809"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-minimal-agent:EAP-nanoserver-1809
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "windows")
+		}
+		
+		script {
+			 name = "context teamcity-agent:EAP-windowsservercore-1809"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity/webapps >> context/.dockerignore
+		echo TeamCity/devPackage >> context/.dockerignore
+		echo TeamCity/lib >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-agent:EAP-windowsservercore-1809"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/windows/Agent/windowsservercore/1809/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-agent:EAP-windowsservercore-1809
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "windows")
+		}
+		
+		script {
+			 name = "context teamcity-agent:EAP-nanoserver-1809"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity/webapps >> context/.dockerignore
+		echo TeamCity/devPackage >> context/.dockerignore
+		echo TeamCity/lib >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-agent:EAP-nanoserver-1809"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/windows/Agent/nanoserver/1809/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-agent:EAP-nanoserver-1809
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "windows")
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-server:EAP-nanoserver-1809"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-server:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-minimal-agent:EAP-nanoserver-1809"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent:EAP-windowsservercore-1809"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent:EAP-nanoserver-1809"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-server:EAP-nanoserver-1809"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809
+		""".trimIndent()
+				 removeImageAfterPush = false
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-agent:EAP-nanoserver-1809
-	""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-minimal-agent:EAP-nanoserver-1809"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent:EAP-windowsservercore-1809"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent:EAP-nanoserver-1809"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
 	}
-	param("dockerImage.platform", "windows")
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-server:EAP-nanoserver-1809"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-server:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+	features {
+		freeDiskSpace {
+			 requiredSpace = "43gb"
+			 failBuild = true
+		}
+		dockerSupport {
+			 cleanupPushedImages = true
+			 loginToRegistry = on {
+				 dockerRegistryId = "PROJECT_EXT_774"
+			 }
+		}
+		swabra {
+			 forceCleanCheckout = true
 		}
 	}
-	
-	dockerCommand {
-		 name = "tag teamcity-minimal-agent:EAP-nanoserver-1809"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		}
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent:EAP-windowsservercore-1809"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-agent:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-		}
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent:EAP-nanoserver-1809"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-server:EAP-nanoserver-1809"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-minimal-agent:EAP-nanoserver-1809"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent:EAP-windowsservercore-1809"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent:EAP-nanoserver-1809"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-}
-features {
-	freeDiskSpace {
-		 requiredSpace = "43gb"
-		 failBuild = true
-	}
-	dockerSupport {
-		 cleanupPushedImages = true
-		 loginToRegistry = on {
-			 dockerRegistryId = "PROJECT_EXT_774"
-		 }
-	}
-	swabra {
-		 forceCleanCheckout = true
-	}
-}
 	dependencies {
 		 dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
 			 snapshot {
@@ -258,8 +258,8 @@ features {
 		 param("system.teamcity.agent.ensure.free.space", "43gb")
 	}
 	requirements {
-	contains("system.agent.name", "docker")
-	contains("system.agent.name", "windows10")
+		 contains("system.agent.name", "docker")
+		 contains("system.agent.name", "windows10")
 	}
 })
 

--- a/.teamcity/generated/PushLocalWindows1903.kts
+++ b/.teamcity/generated/PushLocalWindows1903.kts
@@ -23,7 +23,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-	 object push_local_windows_1903 : BuildType({
+object push_local_windows_1903 : BuildType({
 	 name = "ON PAUSE Build and push windows 1903"
 	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 	 description  = "teamcity-server:EAP-nanoserver-1903,EAP teamcity-minimal-agent:EAP-nanoserver-1903,EAP teamcity-agent:EAP-windowsservercore-1903,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1903,EAP"

--- a/.teamcity/generated/PushLocalWindows1903.kts
+++ b/.teamcity/generated/PushLocalWindows1903.kts
@@ -1,18 +1,31 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object push_local_windows_1903 : BuildType({
-name = "ON PAUSE Build and push windows 1903"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-description  = "teamcity-server:EAP-nanoserver-1903,EAP teamcity-minimal-agent:EAP-nanoserver-1903,EAP teamcity-agent:EAP-windowsservercore-1903,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1903,EAP"
+	 object push_local_windows_1903 : BuildType({
+	 name = "ON PAUSE Build and push windows 1903"
+	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 description  = "teamcity-server:EAP-nanoserver-1903,EAP teamcity-minimal-agent:EAP-nanoserver-1903,EAP teamcity-agent:EAP-windowsservercore-1903,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1903,EAP"
 })
 

--- a/.teamcity/generated/PushLocalWindows1909.kts
+++ b/.teamcity/generated/PushLocalWindows1909.kts
@@ -1,18 +1,31 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object push_local_windows_1909 : BuildType({
-name = "ON PAUSE Build and push windows 1909"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-description  = "teamcity-server:EAP-nanoserver-1909,EAP teamcity-minimal-agent:EAP-nanoserver-1909,EAP teamcity-agent:EAP-windowsservercore-1909,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1909,EAP"
+	 object push_local_windows_1909 : BuildType({
+	 name = "ON PAUSE Build and push windows 1909"
+	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 description  = "teamcity-server:EAP-nanoserver-1909,EAP teamcity-minimal-agent:EAP-nanoserver-1909,EAP teamcity-agent:EAP-windowsservercore-1909,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1909,EAP"
 })
 

--- a/.teamcity/generated/PushLocalWindows1909.kts
+++ b/.teamcity/generated/PushLocalWindows1909.kts
@@ -23,7 +23,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-	 object push_local_windows_1909 : BuildType({
+object push_local_windows_1909 : BuildType({
 	 name = "ON PAUSE Build and push windows 1909"
 	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 	 description  = "teamcity-server:EAP-nanoserver-1909,EAP teamcity-minimal-agent:EAP-nanoserver-1909,EAP teamcity-agent:EAP-windowsservercore-1909,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1909,EAP"

--- a/.teamcity/generated/PushLocalWindows2004.kts
+++ b/.teamcity/generated/PushLocalWindows2004.kts
@@ -158,33 +158,33 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 	dockerCommand {
 		 name = "tag teamcity-server:EAP-nanoserver-2004"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-server:EAP-nanoserver-2004 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-server:EAP-nanoserver-2004 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-minimal-agent:EAP-nanoserver-2004"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-agent:EAP-windowsservercore-2004"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-agent:EAP-windowsservercore-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-agent:EAP-windowsservercore-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+		}
 	}
 	
 	dockerCommand {
 		 name = "tag teamcity-agent:EAP-nanoserver-2004"
 		 commandType = other {
-		 subCommand = "tag"
-		 commandArgs = "teamcity-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-	}
+			 subCommand = "tag"
+			 commandArgs = "teamcity-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+		}
 	}
 	
 	dockerCommand {
@@ -193,7 +193,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -203,7 +203,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -213,7 +213,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	
@@ -223,7 +223,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 			 namesAndTags = """
 	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
 	""".trimIndent()
-		 removeImageAfterPush = false
+			 removeImageAfterPush = false
 		 }
 	}
 	

--- a/.teamcity/generated/PushLocalWindows2004.kts
+++ b/.teamcity/generated/PushLocalWindows2004.kts
@@ -1,247 +1,265 @@
+// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
+// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
+// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-object push_local_windows_2004 : BuildType({
-name = "Build and push windows 2004"
-buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-description  = "teamcity-server:EAP-nanoserver-2004,EAP teamcity-minimal-agent:EAP-nanoserver-2004,EAP teamcity-agent:EAP-windowsservercore-2004,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-2004,EAP"
-vcs {root(TeamCityDockerImagesRepo)}
-steps {
-dockerCommand {
-name = "pull mcr.microsoft.com/powershell:nanoserver-2004"
-commandType = other {
-subCommand = "pull"
-commandArgs = "mcr.microsoft.com/powershell:nanoserver-2004"
-}
-}
+	 object push_local_windows_2004 : BuildType({
+	 name = "Build and push windows 2004"
+	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 description  = "teamcity-server:EAP-nanoserver-2004,EAP teamcity-minimal-agent:EAP-nanoserver-2004,EAP teamcity-agent:EAP-windowsservercore-2004,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-2004,EAP"
+	 vcs {
+		 root(TeamCityDockerImagesRepo)
+	 }
 
-dockerCommand {
-name = "pull mcr.microsoft.com/windows/nanoserver:2004"
-commandType = other {
-subCommand = "pull"
-commandArgs = "mcr.microsoft.com/windows/nanoserver:2004"
-}
-}
-
-dockerCommand {
-name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
-commandType = other {
-subCommand = "pull"
-commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
-}
-}
-
-script {
-name = "context teamcity-server:EAP-nanoserver-2004"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity/buildAgent >> context/.dockerignore
-echo TeamCity/temp >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-server:EAP-nanoserver-2004"
-commandType = build {
-source = file {
-path = """context/generated/windows/Server/nanoserver/2004/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-server:EAP-nanoserver-2004
-""".trimIndent()
-}
-param("dockerImage.platform", "windows")
-}
-
-script {
-name = "context teamcity-minimal-agent:EAP-nanoserver-2004"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity/webapps >> context/.dockerignore
-echo TeamCity/devPackage >> context/.dockerignore
-echo TeamCity/lib >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-minimal-agent:EAP-nanoserver-2004"
-commandType = build {
-source = file {
-path = """context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-minimal-agent:EAP-nanoserver-2004
-""".trimIndent()
-}
-param("dockerImage.platform", "windows")
-}
-
-script {
-name = "context teamcity-agent:EAP-windowsservercore-2004"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity/webapps >> context/.dockerignore
-echo TeamCity/devPackage >> context/.dockerignore
-echo TeamCity/lib >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-agent:EAP-windowsservercore-2004"
-commandType = build {
-source = file {
-path = """context/generated/windows/Agent/windowsservercore/2004/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-agent:EAP-windowsservercore-2004
-""".trimIndent()
-}
-param("dockerImage.platform", "windows")
-}
-
-script {
-name = "context teamcity-agent:EAP-nanoserver-2004"
-scriptContent = """
-echo 2> context/.dockerignore
-echo TeamCity/webapps >> context/.dockerignore
-echo TeamCity/devPackage >> context/.dockerignore
-echo TeamCity/lib >> context/.dockerignore
-""".trimIndent()
-}
-
-dockerCommand {
-name = "build teamcity-agent:EAP-nanoserver-2004"
-commandType = build {
-source = file {
-path = """context/generated/windows/Agent/nanoserver/2004/Dockerfile"""
-}
-contextDir = "context"
-commandArgs = "--no-cache"
-namesAndTags = """
-teamcity-agent:EAP-nanoserver-2004
-""".trimIndent()
-}
-param("dockerImage.platform", "windows")
-}
-
-dockerCommand {
-name = "tag teamcity-server:EAP-nanoserver-2004"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-server:EAP-nanoserver-2004 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-minimal-agent:EAP-nanoserver-2004"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-minimal-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent:EAP-windowsservercore-2004"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-agent:EAP-windowsservercore-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-}
-}
-
-dockerCommand {
-name = "tag teamcity-agent:EAP-nanoserver-2004"
-commandType = other {
-subCommand = "tag"
-commandArgs = "teamcity-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-}
-}
-
-dockerCommand {
-name = "push teamcity-server:EAP-nanoserver-2004"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "push teamcity-minimal-agent:EAP-nanoserver-2004"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent:EAP-windowsservercore-2004"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
-dockerCommand {
-name = "push teamcity-agent:EAP-nanoserver-2004"
-commandType = push {
-namesAndTags = """
-%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
-""".trimIndent()
-removeImageAfterPush = false
-}
-}
-
+ steps {
+	dockerCommand {
+		 name = "pull mcr.microsoft.com/powershell:nanoserver-2004"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "mcr.microsoft.com/powershell:nanoserver-2004"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull mcr.microsoft.com/windows/nanoserver:2004"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "mcr.microsoft.com/windows/nanoserver:2004"
+		 }
+	}
+	
+	dockerCommand {
+		 name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
+		 commandType = other {
+			 subCommand = "pull"
+			 commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
+		 }
+	}
+	
+	script {
+		 name = "context teamcity-server:EAP-nanoserver-2004"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity/buildAgent >> context/.dockerignore
+	echo TeamCity/temp >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-server:EAP-nanoserver-2004"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/windows/Server/nanoserver/2004/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-server:EAP-nanoserver-2004
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "windows")
+	}
+	
+	script {
+		 name = "context teamcity-minimal-agent:EAP-nanoserver-2004"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity/webapps >> context/.dockerignore
+	echo TeamCity/devPackage >> context/.dockerignore
+	echo TeamCity/lib >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-minimal-agent:EAP-nanoserver-2004"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-minimal-agent:EAP-nanoserver-2004
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "windows")
+	}
+	
+	script {
+		 name = "context teamcity-agent:EAP-windowsservercore-2004"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity/webapps >> context/.dockerignore
+	echo TeamCity/devPackage >> context/.dockerignore
+	echo TeamCity/lib >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-agent:EAP-windowsservercore-2004"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/windows/Agent/windowsservercore/2004/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-agent:EAP-windowsservercore-2004
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "windows")
+	}
+	
+	script {
+		 name = "context teamcity-agent:EAP-nanoserver-2004"
+		 scriptContent = """
+	echo 2> context/.dockerignore
+	echo TeamCity/webapps >> context/.dockerignore
+	echo TeamCity/devPackage >> context/.dockerignore
+	echo TeamCity/lib >> context/.dockerignore
+	""".trimIndent()
+	}
+	
+	dockerCommand {
+		 name = "build teamcity-agent:EAP-nanoserver-2004"
+		 commandType = build {
+			 source = file {
+			 path = """context/generated/windows/Agent/nanoserver/2004/Dockerfile"""
+			 }
+		 contextDir = "context"
+		 commandArgs = "--no-cache"
+		 namesAndTags = """
+	teamcity-agent:EAP-nanoserver-2004
+	""".trimIndent()
+	}
+	param("dockerImage.platform", "windows")
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-server:EAP-nanoserver-2004"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-server:EAP-nanoserver-2004 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-minimal-agent:EAP-nanoserver-2004"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent:EAP-windowsservercore-2004"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-agent:EAP-windowsservercore-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+	}
+	}
+	
+	dockerCommand {
+		 name = "tag teamcity-agent:EAP-nanoserver-2004"
+		 commandType = other {
+		 subCommand = "tag"
+		 commandArgs = "teamcity-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+	}
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-server:EAP-nanoserver-2004"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-minimal-agent:EAP-nanoserver-2004"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent:EAP-windowsservercore-2004"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
+	dockerCommand {
+		 name = "push teamcity-agent:EAP-nanoserver-2004"
+		 commandType = push {
+			 namesAndTags = """
+	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
+	""".trimIndent()
+		 removeImageAfterPush = false
+		 }
+	}
+	
 }
 features {
-freeDiskSpace {
-requiredSpace = "43gb"
-failBuild = true
+	freeDiskSpace {
+		 requiredSpace = "43gb"
+		 failBuild = true
+	}
+	dockerSupport {
+		 cleanupPushedImages = true
+		 loginToRegistry = on {
+			 dockerRegistryId = "PROJECT_EXT_774"
+		 }
+	}
+	swabra {
+		 forceCleanCheckout = true
+	}
 }
-dockerSupport {
-cleanupPushedImages = true
-loginToRegistry = on {
-dockerRegistryId = "PROJECT_EXT_774"
-}
-}
-swabra {
-forceCleanCheckout = true
-}
-}
-dependencies {
-dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
-snapshot { onDependencyFailure = FailureAction.IGNORE
-reuseBuilds = ReuseBuilds.ANY }
-artifacts {
-artifactRules = "TeamCity.zip!/**=>context/TeamCity"
-}
-}
-}
-params {
-param("system.teamcity.agent.ensure.free.space", "43gb")
-}
-requirements {
-contains("system.agent.name", "docker")
-contains("system.agent.name", "windows10")
-}
+	dependencies {
+		 dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
+			 snapshot {
+				 onDependencyFailure = FailureAction.IGNORE
+				 reuseBuilds = ReuseBuilds.ANY
+			 }
+			 artifacts {
+				 artifactRules = "TeamCity.zip!/**=>context/TeamCity"
+			 }
+		 }
+	}
+	params {
+		 param("system.teamcity.agent.ensure.free.space", "43gb")
+	}
+	requirements {
+	contains("system.agent.name", "docker")
+	contains("system.agent.name", "windows10")
+	}
 })
 

--- a/.teamcity/generated/PushLocalWindows2004.kts
+++ b/.teamcity/generated/PushLocalWindows2004.kts
@@ -23,7 +23,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-	 object push_local_windows_2004 : BuildType({
+object push_local_windows_2004 : BuildType({
 	 name = "Build and push windows 2004"
 	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 	 description  = "teamcity-server:EAP-nanoserver-2004,EAP teamcity-minimal-agent:EAP-nanoserver-2004,EAP teamcity-agent:EAP-windowsservercore-2004,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-2004,EAP"
@@ -31,218 +31,218 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 		 root(TeamCityDockerImagesRepo)
 	 }
 
- steps {
-	dockerCommand {
-		 name = "pull mcr.microsoft.com/powershell:nanoserver-2004"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "mcr.microsoft.com/powershell:nanoserver-2004"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull mcr.microsoft.com/windows/nanoserver:2004"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "mcr.microsoft.com/windows/nanoserver:2004"
-		 }
-	}
-	
-	dockerCommand {
-		 name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
-		 commandType = other {
-			 subCommand = "pull"
-			 commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
-		 }
-	}
-	
-	script {
-		 name = "context teamcity-server:EAP-nanoserver-2004"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity/buildAgent >> context/.dockerignore
-	echo TeamCity/temp >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-server:EAP-nanoserver-2004"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/windows/Server/nanoserver/2004/Dockerfile"""
+ 	 steps {
+		dockerCommand {
+			 name = "pull mcr.microsoft.com/powershell:nanoserver-2004"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "mcr.microsoft.com/powershell:nanoserver-2004"
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-server:EAP-nanoserver-2004
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "windows")
-	}
-	
-	script {
-		 name = "context teamcity-minimal-agent:EAP-nanoserver-2004"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity/webapps >> context/.dockerignore
-	echo TeamCity/devPackage >> context/.dockerignore
-	echo TeamCity/lib >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-minimal-agent:EAP-nanoserver-2004"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile"""
+		}
+		
+		dockerCommand {
+			 name = "pull mcr.microsoft.com/windows/nanoserver:2004"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "mcr.microsoft.com/windows/nanoserver:2004"
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-minimal-agent:EAP-nanoserver-2004
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "windows")
-	}
-	
-	script {
-		 name = "context teamcity-agent:EAP-windowsservercore-2004"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity/webapps >> context/.dockerignore
-	echo TeamCity/devPackage >> context/.dockerignore
-	echo TeamCity/lib >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-agent:EAP-windowsservercore-2004"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/windows/Agent/windowsservercore/2004/Dockerfile"""
+		}
+		
+		dockerCommand {
+			 name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-agent:EAP-windowsservercore-2004
-	""".trimIndent()
-	}
-	param("dockerImage.platform", "windows")
-	}
-	
-	script {
-		 name = "context teamcity-agent:EAP-nanoserver-2004"
-		 scriptContent = """
-	echo 2> context/.dockerignore
-	echo TeamCity/webapps >> context/.dockerignore
-	echo TeamCity/devPackage >> context/.dockerignore
-	echo TeamCity/lib >> context/.dockerignore
-	""".trimIndent()
-	}
-	
-	dockerCommand {
-		 name = "build teamcity-agent:EAP-nanoserver-2004"
-		 commandType = build {
-			 source = file {
-			 path = """context/generated/windows/Agent/nanoserver/2004/Dockerfile"""
+		}
+		
+		script {
+			 name = "context teamcity-server:EAP-nanoserver-2004"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity/buildAgent >> context/.dockerignore
+		echo TeamCity/temp >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-server:EAP-nanoserver-2004"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/windows/Server/nanoserver/2004/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-server:EAP-nanoserver-2004
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "windows")
+		}
+		
+		script {
+			 name = "context teamcity-minimal-agent:EAP-nanoserver-2004"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity/webapps >> context/.dockerignore
+		echo TeamCity/devPackage >> context/.dockerignore
+		echo TeamCity/lib >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-minimal-agent:EAP-nanoserver-2004"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-minimal-agent:EAP-nanoserver-2004
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "windows")
+		}
+		
+		script {
+			 name = "context teamcity-agent:EAP-windowsservercore-2004"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity/webapps >> context/.dockerignore
+		echo TeamCity/devPackage >> context/.dockerignore
+		echo TeamCity/lib >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-agent:EAP-windowsservercore-2004"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/windows/Agent/windowsservercore/2004/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-agent:EAP-windowsservercore-2004
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "windows")
+		}
+		
+		script {
+			 name = "context teamcity-agent:EAP-nanoserver-2004"
+			 scriptContent = """
+		echo 2> context/.dockerignore
+		echo TeamCity/webapps >> context/.dockerignore
+		echo TeamCity/devPackage >> context/.dockerignore
+		echo TeamCity/lib >> context/.dockerignore
+		""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "build teamcity-agent:EAP-nanoserver-2004"
+			 commandType = build {
+				 source = file {
+				 path = """context/generated/windows/Agent/nanoserver/2004/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
+		teamcity-agent:EAP-nanoserver-2004
+		""".trimIndent()
+		}
+		param("dockerImage.platform", "windows")
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-server:EAP-nanoserver-2004"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-server:EAP-nanoserver-2004 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-minimal-agent:EAP-nanoserver-2004"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent:EAP-windowsservercore-2004"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-windowsservercore-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+			}
+		}
+		
+		dockerCommand {
+			 name = "tag teamcity-agent:EAP-nanoserver-2004"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			}
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-server:EAP-nanoserver-2004"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004
+		""".trimIndent()
+				 removeImageAfterPush = false
 			 }
-		 contextDir = "context"
-		 commandArgs = "--no-cache"
-		 namesAndTags = """
-	teamcity-agent:EAP-nanoserver-2004
-	""".trimIndent()
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-minimal-agent:EAP-nanoserver-2004"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent:EAP-windowsservercore-2004"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 name = "push teamcity-agent:EAP-nanoserver-2004"
+			 commandType = push {
+				 namesAndTags = """
+		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
+		""".trimIndent()
+				 removeImageAfterPush = false
+			 }
+		}
+		
 	}
-	param("dockerImage.platform", "windows")
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-server:EAP-nanoserver-2004"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-server:EAP-nanoserver-2004 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+	features {
+		freeDiskSpace {
+			 requiredSpace = "43gb"
+			 failBuild = true
+		}
+		dockerSupport {
+			 cleanupPushedImages = true
+			 loginToRegistry = on {
+				 dockerRegistryId = "PROJECT_EXT_774"
+			 }
+		}
+		swabra {
+			 forceCleanCheckout = true
 		}
 	}
-	
-	dockerCommand {
-		 name = "tag teamcity-minimal-agent:EAP-nanoserver-2004"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		}
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent:EAP-windowsservercore-2004"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-agent:EAP-windowsservercore-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-		}
-	}
-	
-	dockerCommand {
-		 name = "tag teamcity-agent:EAP-nanoserver-2004"
-		 commandType = other {
-			 subCommand = "tag"
-			 commandArgs = "teamcity-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		}
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-server:EAP-nanoserver-2004"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-minimal-agent:EAP-nanoserver-2004"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent:EAP-windowsservercore-2004"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-	dockerCommand {
-		 name = "push teamcity-agent:EAP-nanoserver-2004"
-		 commandType = push {
-			 namesAndTags = """
-	%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
-	""".trimIndent()
-			 removeImageAfterPush = false
-		 }
-	}
-	
-}
-features {
-	freeDiskSpace {
-		 requiredSpace = "43gb"
-		 failBuild = true
-	}
-	dockerSupport {
-		 cleanupPushedImages = true
-		 loginToRegistry = on {
-			 dockerRegistryId = "PROJECT_EXT_774"
-		 }
-	}
-	swabra {
-		 forceCleanCheckout = true
-	}
-}
 	dependencies {
 		 dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
 			 snapshot {
@@ -258,8 +258,8 @@ features {
 		 param("system.teamcity.agent.ensure.free.space", "43gb")
 	}
 	requirements {
-	contains("system.agent.name", "docker")
-	contains("system.agent.name", "windows10")
+		 contains("system.agent.name", "docker")
+		 contains("system.agent.name", "windows10")
 	}
 })
 

--- a/tool/TeamCity.Docker/TeamCityKotlinSettingsGenerator.cs
+++ b/tool/TeamCity.Docker/TeamCityKotlinSettingsGenerator.cs
@@ -941,7 +941,7 @@ namespace TeamCity.Docker
 
             yield return "\"\"\".trimIndent()";
             
-            yield return "\t removeImageAfterPush = false";
+            yield return "\t\t removeImageAfterPush = false";
 
             yield return "\t }";
             yield return "}";
@@ -961,10 +961,10 @@ namespace TeamCity.Docker
             yield return $"\t name = \"tag {name}\"";
             yield return "\t commandType = other {";
 
-            yield return "\t subCommand = \"tag\"";
-            yield return $"\t commandArgs = \"{repoTag} {newRepoTag}\"";
+            yield return "\t\t subCommand = \"tag\"";
+            yield return $"\t\t commandArgs = \"{repoTag} {newRepoTag}\"";
 
-            yield return "}";
+            yield return "\t}";
             yield return "}";
 
             yield return string.Empty;
@@ -1051,7 +1051,7 @@ namespace TeamCity.Docker
             yield return "dockerCommand {";
             yield return $"\t name = \"{name}\"";
             yield return "\t commandType = other {";
-            yield return $"\t subCommand = \"{command}\"";
+            yield return $"\t\t subCommand = \"{command}\"";
             yield return $"\t\t commandArgs = \"{string.Join(" ", args)}\"";
             yield return "\t }";
             yield return "}";


### PR DESCRIPTION
This pull request (PR) represents part of the changes originated related to validation of TeamCity Docker images.
The original PR - https://github.com/JetBrains/teamcity-docker-images/pull/43 - contains changes related to logic inside of the compiling code, such as automation framework, visualization script of build configuration DSL generator, while the current PR includes re-generated DSLs that we store inside of repository.
The pull requests were separated in purpose of more convenient review of the changes.

As for DSL generation, it includes enhanced tabulation, thus the file will be readable from Git sources without the need to manually reformat it.