### PR TITLE
Create/Support Windows Server 2022 (ltsc2022)

### DIFF
--- a/.teamcity/generated/HubProject.kts
+++ b/.teamcity/generated/HubProject.kts
@@ -1,31 +1,18 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
 object HubProject : Project({
-	 name = "Docker hub"
-	 buildType(PushHubLinux.push_hub_linux)
-	 buildType(PushHubWindows.push_hub_windows)
-	 buildType(PublishHubVersion.publish_hub_version)
+name = "Docker hub"
+buildType(PushHubLinux.push_hub_linux)
+buildType(PushHubWindows.push_hub_windows)
+buildType(PublishHubVersion.publish_hub_version)
 })

--- a/.teamcity/generated/LocalProject.kts
+++ b/.teamcity/generated/LocalProject.kts
@@ -1,37 +1,24 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
 object LocalProject : Project({
-	 name = "Staging registry"
-	 buildType(PushLocalLinux1804.push_local_linux_18_04)
-	 buildType(PushLocalLinux2004.push_local_linux_20_04)
-	 buildType(PushLocalWindows1803.push_local_windows_1803)
-	 buildType(PushLocalWindows1809.push_local_windows_1809)
-	 buildType(PushLocalWindows1903.push_local_windows_1903)
-	 buildType(PushLocalWindows1909.push_local_windows_1909)
-	 buildType(PushLocalWindows2004.push_local_windows_2004)
-	 buildType(PublishLocal.publish_local)
-	 buildType(ImageValidation.image_validation)
+name = "Staging registry"
+buildType(PushLocalLinux1804.push_local_linux_18_04)
+buildType(PushLocalLinux2004.push_local_linux_20_04)
+buildType(PushLocalWindows1803.push_local_windows_1803)
+buildType(PushLocalWindows1809.push_local_windows_1809)
+buildType(PushLocalWindows1903.push_local_windows_1903)
+buildType(PushLocalWindows1909.push_local_windows_1909)
+buildType(PushLocalWindows2004.push_local_windows_2004)
+buildType(PushLocalWindowsLtsc2022.push_local_windows_ltsc2022)
+buildType(PublishLocal.publish_local)
 })

--- a/.teamcity/generated/PublishHubVersion.kts
+++ b/.teamcity/generated/PublishHubVersion.kts
@@ -1,152 +1,139 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
-object publish_hub_version: BuildType({
-	 name = "Publish as version"
-	buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-	 enablePersonalBuilds = false
-	 type = BuildTypeSettings.Type.DEPLOYMENT
-	 maxRunningBuilds = 1
-	 steps {
-		 script {
-		 	 name = "remove manifests"
-		 	 scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
-		 }
-	dockerCommand {
-		 name = "manifest create teamcity-server:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "create %docker.deployRepository%teamcity-server:EAP %docker.deployRepository%teamcity-server:EAP-linux %docker.deployRepository%teamcity-server:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest push teamcity-server:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "push %docker.deployRepository%teamcity-server:EAP"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest inspect teamcity-server:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "inspect %docker.deployRepository%teamcity-server:EAP --verbose"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest create teamcity-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP %docker.deployRepository%teamcity-agent:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest push teamcity-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "push %docker.deployRepository%teamcity-agent:EAP"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest inspect teamcity-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP --verbose"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest create teamcity-minimal-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "create %docker.deployRepository%teamcity-minimal-agent:EAP %docker.deployRepository%teamcity-minimal-agent:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest push teamcity-minimal-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "push %docker.deployRepository%teamcity-minimal-agent:EAP"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest inspect teamcity-minimal-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "inspect %docker.deployRepository%teamcity-minimal-agent:EAP --verbose"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest create teamcity-agent:EAP-windowsservercore"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP-windowsservercore %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest push teamcity-agent:EAP-windowsservercore"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "push %docker.deployRepository%teamcity-agent:EAP-windowsservercore"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest inspect teamcity-agent:EAP-windowsservercore"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP-windowsservercore --verbose"
-		 }
-	}
-	 }
-		 dependencies {
-			 snapshot(AbsoluteId("TC_Trunk_BuildDistDocker")) {
-
-				 reuseBuilds = ReuseBuilds.ANY 
- 			 onDependencyFailure = FailureAction.IGNORE 
-	 }
-			 snapshot(PushHubLinux.push_hub_linux) {
-
-				 onDependencyFailure =  FailureAction.FAIL_TO_START 
- 		 }
-			 snapshot(PushHubWindows.push_hub_windows) {
-
-				 onDependencyFailure =  FailureAction.FAIL_TO_START 
- 		 }
-		 }
-	requirements {
-		 noLessThanVer("docker.version", "18.05.0")
-		 contains("docker.server.osType", "windows")
-		 contains("system.agent.name", "docker")
-		 contains("system.agent.name", "windows10")
-	}
-	 features {
-		 dockerSupport {
-		 	 cleanupPushedImages = true
-		 	 loginToRegistry = on {
-		 		 dockerRegistryId = "PROJECT_EXT_774"
-		 	 }
-		 }
-	}
+object publish_hub_version: BuildType(
+{
+name = "Publish as version"
+buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+enablePersonalBuilds = false
+type = BuildTypeSettings.Type.DEPLOYMENT
+maxRunningBuilds = 1
+steps {
+script {
+name = "remove manifests"
+scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
+}
+dockerCommand {
+name = "manifest create teamcity-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "create %docker.deployRepository%teamcity-agent:EAP %docker.deployRepository%teamcity-agent:EAP-linux %docker.deployRepository%teamcity-agent:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004 %docker.deployRepository%teamcity-agent:EAP-nanoserver-ltsc2022"
+}
+}
+dockerCommand {
+name = "manifest push teamcity-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "push %docker.deployRepository%teamcity-agent:EAP"
+}
+}
+dockerCommand {
+name = "manifest inspect teamcity-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP --verbose"
+}
+}
+dockerCommand {
+name = "manifest create teamcity-minimal-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "create %docker.deployRepository%teamcity-minimal-agent:EAP %docker.deployRepository%teamcity-minimal-agent:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-ltsc2022"
+}
+}
+dockerCommand {
+name = "manifest push teamcity-minimal-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "push %docker.deployRepository%teamcity-minimal-agent:EAP"
+}
+}
+dockerCommand {
+name = "manifest inspect teamcity-minimal-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "inspect %docker.deployRepository%teamcity-minimal-agent:EAP --verbose"
+}
+}
+dockerCommand {
+name = "manifest create teamcity-server:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "create %docker.deployRepository%teamcity-server:EAP %docker.deployRepository%teamcity-server:EAP-linux %docker.deployRepository%teamcity-server:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004 %docker.deployRepository%teamcity-server:EAP-nanoserver-ltsc2022"
+}
+}
+dockerCommand {
+name = "manifest push teamcity-server:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "push %docker.deployRepository%teamcity-server:EAP"
+}
+}
+dockerCommand {
+name = "manifest inspect teamcity-server:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "inspect %docker.deployRepository%teamcity-server:EAP --verbose"
+}
+}
+dockerCommand {
+name = "manifest create teamcity-agent:EAP-windowsservercore"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "create %docker.deployRepository%teamcity-agent:EAP-windowsservercore %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-ltsc2022"
+}
+}
+dockerCommand {
+name = "manifest push teamcity-agent:EAP-windowsservercore"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "push %docker.deployRepository%teamcity-agent:EAP-windowsservercore"
+}
+}
+dockerCommand {
+name = "manifest inspect teamcity-agent:EAP-windowsservercore"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "inspect %docker.deployRepository%teamcity-agent:EAP-windowsservercore --verbose"
+}
+}
+}
+dependencies {
+snapshot(AbsoluteId("TC_Trunk_BuildDistDocker"))
+{
+reuseBuilds = ReuseBuilds.ANY
+onDependencyFailure = FailureAction.IGNORE
+}
+snapshot(PushHubLinux.push_hub_linux)
+{
+onDependencyFailure =  FailureAction.FAIL_TO_START
+}
+snapshot(PushHubWindows.push_hub_windows)
+{
+onDependencyFailure =  FailureAction.FAIL_TO_START
+}
+}
+requirements {
+noLessThanVer("docker.version", "18.05.0")
+contains("docker.server.osType", "windows")
+contains("teamcity.agent.jvm.os.name", "Windows")
+}
+features {
+dockerSupport {
+cleanupPushedImages = true
+loginToRegistry = on {
+dockerRegistryId = "PROJECT_EXT_774"
+}
+}
+}
 })
 

--- a/.teamcity/generated/PublishLocal.kts
+++ b/.teamcity/generated/PublishLocal.kts
@@ -1,157 +1,148 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
-object publish_local: BuildType({
-	 name = "Publish"
-	buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-	 enablePersonalBuilds = false
-	 type = BuildTypeSettings.Type.DEPLOYMENT
-	 maxRunningBuilds = 1
-	 steps {
-		 script {
-		 	 name = "remove manifests"
-		 	 scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
-		 }
-	dockerCommand {
-		 name = "manifest create teamcity-server:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest push teamcity-server:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "push %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest inspect teamcity-server:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "inspect %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP --verbose"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest create teamcity-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest push teamcity-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest inspect teamcity-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP --verbose"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest create teamcity-minimal-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest push teamcity-minimal-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "push %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest inspect teamcity-minimal-agent:EAP"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "inspect %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP --verbose"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest create teamcity-agent:EAP-windowsservercore"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest push teamcity-agent:EAP-windowsservercore"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore"
-		 }
-	}
-	dockerCommand {
-		 name = "manifest inspect teamcity-agent:EAP-windowsservercore"
-		 commandType = other {
-			 subCommand = "manifest"
-			 commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore --verbose"
-		 }
-	}
-	 }
-		 dependencies {
-			 snapshot(AbsoluteId("TC_Trunk_BuildDistDocker")) {
-
-				 onDependencyFailure = FailureAction.FAIL_TO_START 
- 			 reuseBuilds = ReuseBuilds.ANY 
- 			 synchronizeRevisions = false 
- 		 }
-			 snapshot(PushLocalLinux2004.push_local_linux_20_04) {
-
-				 onDependencyFailure =  FailureAction.FAIL_TO_START 
- 		 }
-			 snapshot(PushLocalWindows1809.push_local_windows_1809) {
-
-				 onDependencyFailure =  FailureAction.FAIL_TO_START 
- 		 }
-			 snapshot(PushLocalWindows2004.push_local_windows_2004) {
-
-				 onDependencyFailure =  FailureAction.FAIL_TO_START 
- 		 }
-		 }
-	requirements {
-		 noLessThanVer("docker.version", "18.05.0")
-		 contains("docker.server.osType", "windows")
-		 contains("system.agent.name", "docker")
-		 contains("system.agent.name", "windows10")
-	}
-	 features {
-		 dockerSupport {
-		 	 cleanupPushedImages = true
-		 	 loginToRegistry = on {
-		 		 dockerRegistryId = "PROJECT_EXT_774"
-		 	 }
-		 }
-	}
+object publish_local: BuildType(
+{
+name = "Publish"
+buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+enablePersonalBuilds = false
+type = BuildTypeSettings.Type.DEPLOYMENT
+maxRunningBuilds = 1
+steps {
+script {
+name = "remove manifests"
+scriptContent = """if exist "%%USERPROFILE%%\.docker\manifests\" rmdir "%%USERPROFILE%%\.docker\manifests\" /s /q"""
+}
+dockerCommand {
+name = "manifest create teamcity-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+}
+}
+dockerCommand {
+name = "manifest push teamcity-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP"
+}
+}
+dockerCommand {
+name = "manifest inspect teamcity-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP --verbose"
+}
+}
+dockerCommand {
+name = "manifest create teamcity-minimal-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+}
+}
+dockerCommand {
+name = "manifest push teamcity-minimal-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "push %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP"
+}
+}
+dockerCommand {
+name = "manifest inspect teamcity-minimal-agent:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "inspect %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP --verbose"
+}
+}
+dockerCommand {
+name = "manifest create teamcity-server:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+}
+}
+dockerCommand {
+name = "manifest push teamcity-server:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "push %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP"
+}
+}
+dockerCommand {
+name = "manifest inspect teamcity-server:EAP"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "inspect %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP --verbose"
+}
+}
+dockerCommand {
+name = "manifest create teamcity-agent:EAP-windowsservercore"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-ltsc2022"
+}
+}
+dockerCommand {
+name = "manifest push teamcity-agent:EAP-windowsservercore"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "push %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore"
+}
+}
+dockerCommand {
+name = "manifest inspect teamcity-agent:EAP-windowsservercore"
+commandType = other {
+subCommand = "manifest"
+commandArgs = "inspect %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore --verbose"
+}
+}
+}
+dependencies {
+snapshot(AbsoluteId("TC_Trunk_BuildDistDocker"))
+{
+onDependencyFailure = FailureAction.FAIL_TO_START
+reuseBuilds = ReuseBuilds.ANY
+synchronizeRevisions = false
+}
+snapshot(PushLocalLinux2004.push_local_linux_20_04)
+{
+onDependencyFailure =  FailureAction.FAIL_TO_START
+}
+snapshot(PushLocalWindows1809.push_local_windows_1809)
+{
+onDependencyFailure =  FailureAction.FAIL_TO_START
+}
+snapshot(PushLocalWindows2004.push_local_windows_2004)
+{
+onDependencyFailure =  FailureAction.FAIL_TO_START
+}
+snapshot(PushLocalWindowsLtsc2022.push_local_windows_ltsc2022)
+{
+onDependencyFailure =  FailureAction.FAIL_TO_START
+}
+}
+requirements {
+noLessThanVer("docker.version", "18.05.0")
+contains("docker.server.osType", "windows")
+contains("teamcity.agent.jvm.os.name", "Windows")
+}
+features {
+dockerSupport {
+cleanupPushedImages = true
+loginToRegistry = on {
+dockerRegistryId = "PROJECT_EXT_774"
+}
+}
+}
 })
 

--- a/.teamcity/generated/PushHubLinux.kts
+++ b/.teamcity/generated/PushHubLinux.kts
@@ -1,215 +1,203 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
-object push_hub_linux: BuildType({
-	 name = "Push linux"
-	buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-	 steps {
-		dockerCommand {
-			 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-linux"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-linux"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-server:EAP-linux"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-server%docker.buildImagePostfix%:EAP-linux"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-server:EAP-linux
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo %docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux-arm64"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-agent:EAP-linux-arm64
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-agent:EAP-linux"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-agent:EAP-linux
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo %docker.deployRepository%teamcity-agent:EAP-linux-sudo"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-agent:EAP-linux-sudo
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-linux"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-minimal-agent:EAP-linux
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-	 }
-	 features {
-		 freeDiskSpace {
-		 	 requiredSpace = "6gb"
-		 	 failBuild = true
-		 }
-		 dockerSupport {
-		 	 cleanupPushedImages = true
-		 	 loginToRegistry = on {
-		 		 dockerRegistryId = "PROJECT_EXT_774"
-		 	 }
-		 }
-		 swabra {
-		 	 forceCleanCheckout = true
-		 }
-	 }
-	params {
-		 param("system.teamcity.agent.ensure.free.space", "6gb")
-	}
-	 requirements {
-	 	 contains("docker.server.osType", "linux")
-	 }
-		 dependencies {
-			 snapshot(PublishLocal.publish_local) {
+object push_hub_linux: BuildType(
+{
+name = "Push linux"
+buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+steps {
+dockerCommand {
+name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+}
+}
 
-				 onDependencyFailure =  FailureAction.FAIL_TO_START 
- 		 }
-		 }
+dockerCommand {
+name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo %docker.deployRepository%teamcity-agent:EAP-linux-sudo"
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-agent:EAP-linux-sudo
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-agent:EAP-linux"
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-agent:EAP-linux
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo %docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo"
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux-arm64"
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-agent:EAP-linux-arm64
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-minimal-agent:EAP-linux"
+}
+}
+
+dockerCommand {
+name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-minimal-agent:EAP-linux
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-server%docker.buildImagePostfix%:EAP-linux"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-server%docker.buildImagePostfix%:EAP-linux"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux %docker.deployRepository%teamcity-server:EAP-linux"
+}
+}
+
+dockerCommand {
+name = "push teamcity-server%docker.buildImagePostfix%:EAP-linux"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-server:EAP-linux
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+}
+features {
+freeDiskSpace {
+requiredSpace = "6gb"
+failBuild = true
+}
+dockerSupport {
+cleanupPushedImages = true
+loginToRegistry = on {
+dockerRegistryId = "PROJECT_EXT_774"
+}
+}
+swabra {
+forceCleanCheckout = true
+}
+}
+params {
+param("system.teamcity.agent.ensure.free.space", "6gb")
+}
+requirements {
+contains("docker.server.osType", "linux")
+}
+dependencies {
+snapshot(PublishLocal.publish_local)
+{
+onDependencyFailure =  FailureAction.FAIL_TO_START
+}
+}
 })
 

--- a/.teamcity/generated/PushHubWindows.kts
+++ b/.teamcity/generated/PushHubWindows.kts
@@ -1,268 +1,360 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
-object push_hub_windows: BuildType({
-	 name = "Push windows"
-	buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-	 steps {
-		dockerCommand {
-			 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-1809"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-server:EAP-nanoserver-1809
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-agent:EAP-nanoserver-1809
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-server:EAP-nanoserver-2004
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-agent:EAP-nanoserver-2004
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-	 }
-	 features {
-		 freeDiskSpace {
-		 	 requiredSpace = "52gb"
-		 	 failBuild = true
-		 }
-		 dockerSupport {
-		 	 cleanupPushedImages = true
-		 	 loginToRegistry = on {
-		 		 dockerRegistryId = "PROJECT_EXT_774"
-		 	 }
-		 }
-		 swabra {
-		 	 forceCleanCheckout = true
-		 }
-	 }
-	params {
-		 param("system.teamcity.agent.ensure.free.space", "52gb")
-	}
-	 requirements {
-	 	 contains("docker.server.osType", "windows")
-	 	 contains("system.agent.name", "docker")
-	 	 contains("system.agent.name", "windows10")
-	 }
-	dependencies {
-		snapshot(PublishLocal.publish_local) {
-			onDependencyFailure =  FailureAction.FAIL_TO_START 
-		}
-	}
+object push_hub_windows: BuildType(
+{
+name = "Push windows"
+buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+steps {
+dockerCommand {
+name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809"
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-agent:EAP-nanoserver-1809
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809"
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-agent:EAP-windowsservercore-1809
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809"
+}
+}
+
+dockerCommand {
+name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-1809
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.deployRepository%teamcity-server:EAP-nanoserver-1809"
+}
+}
+
+dockerCommand {
+name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-server:EAP-nanoserver-1809
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-agent:EAP-nanoserver-2004
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004"
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-agent:EAP-windowsservercore-2004
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004"
+}
+}
+
+dockerCommand {
+name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-2004
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004 %docker.deployRepository%teamcity-server:EAP-nanoserver-2004"
+}
+}
+
+dockerCommand {
+name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-server:EAP-nanoserver-2004
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022 %docker.deployRepository%teamcity-agent:EAP-nanoserver-ltsc2022"
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-agent:EAP-nanoserver-ltsc2022
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-ltsc2022"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-ltsc2022"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-ltsc2022"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-ltsc2022 %docker.deployRepository%teamcity-agent:EAP-windowsservercore-ltsc2022"
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-ltsc2022"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-agent:EAP-windowsservercore-ltsc2022
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022 %docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-ltsc2022"
+}
+}
+
+dockerCommand {
+name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-minimal-agent:EAP-nanoserver-ltsc2022
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+commandType = other {
+subCommand = "pull"
+commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+commandType = other {
+subCommand = "tag"
+commandArgs = "%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022 %docker.deployRepository%teamcity-server:EAP-nanoserver-ltsc2022"
+}
+}
+
+dockerCommand {
+name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
+commandType = push {
+namesAndTags = """
+%docker.deployRepository%teamcity-server:EAP-nanoserver-ltsc2022
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+}
+features {
+freeDiskSpace {
+requiredSpace = "78gb"
+failBuild = true
+}
+dockerSupport {
+cleanupPushedImages = true
+loginToRegistry = on {
+dockerRegistryId = "PROJECT_EXT_774"
+}
+}
+swabra {
+forceCleanCheckout = true
+}
+}
+params {
+param("system.teamcity.agent.ensure.free.space", "78gb")
+}
+requirements {
+contains("docker.server.osType", "windows")
+contains("teamcity.agent.jvm.os.name", "Windows")
+}
+dependencies {
+snapshot(PublishLocal.publish_local)
+{
+onDependencyFailure =  FailureAction.FAIL_TO_START
+}
+}
 })
 

--- a/.teamcity/generated/PushLocalLinux1804.kts
+++ b/.teamcity/generated/PushLocalLinux1804.kts
@@ -1,31 +1,18 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
 object push_local_linux_18_04 : BuildType({
-	 name = "ON PAUSE Build and push linux 18.04"
-	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-	 description  = "teamcity-server:EAP-linux-arm64-18.04,EAP:EAP-linux-18.04,EAP teamcity-minimal-agent:EAP-linux-arm64-18.04,EAP:EAP-linux-18.04,EAP teamcity-agent:EAP-linux-arm64-18.04,EAP:EAP-linux-arm64-18.04-sudo:EAP-linux-18.04,EAP:EAP-linux-18.04-sudo"
+name = "ON PAUSE Build and push linux 18.04"
+buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+description  = "teamcity-server:EAP-linux-arm64-18.04,EAP:EAP-linux-18.04,EAP teamcity-minimal-agent:EAP-linux-arm64-18.04,EAP:EAP-linux-18.04,EAP teamcity-agent:EAP-linux-arm64-18.04,EAP:EAP-linux-arm64-18.04-sudo:EAP-linux-18.04,EAP:EAP-linux-18.04-sudo"
 })
 

--- a/.teamcity/generated/PushLocalLinux2004.kts
+++ b/.teamcity/generated/PushLocalLinux2004.kts
@@ -1,325 +1,307 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
 object push_local_linux_20_04 : BuildType({
-	 name = "Build and push linux 20.04"
-	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-	 description  = "teamcity-server:EAP-linux,EAP teamcity-minimal-agent:EAP-linux,EAP teamcity-agent:EAP-linux,EAP:EAP-linux-sudo:EAP-linux-arm64,EAP:EAP-linux-arm64-sudo"
-	 vcs {
-		 root(TeamCityDockerImagesRepo)
-	 }
+name = "Build and push linux 20.04"
+buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+description  = "teamcity-server:EAP-linux,EAP teamcity-minimal-agent:EAP-linux,EAP teamcity-agent:EAP-linux,EAP:EAP-linux-sudo:EAP-linux-arm64,EAP:EAP-linux-arm64-sudo"
+vcs {root(TeamCityDockerImagesRepo)}
+steps {
+dockerCommand {
+name = "pull ubuntu:20.04"
+commandType = other {
+subCommand = "pull"
+commandArgs = "ubuntu:20.04"
+}
+}
 
- 	 steps {
-		dockerCommand {
-			 name = "pull ubuntu:20.04"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "ubuntu:20.04"
-			 }
-		}
-		
-		script {
-			 name = "context teamcity-server:EAP-linux"
-			 scriptContent = """
-		echo 2> context/.dockerignore
-		echo TeamCity/buildAgent >> context/.dockerignore
-		echo TeamCity/temp >> context/.dockerignore
-		""".trimIndent()
-		}
-		
-		dockerCommand {
-			 name = "build teamcity-server:EAP-linux"
-			 commandType = build {
-				 source = file {
-				 path = """context/generated/linux/Server/Ubuntu/20.04/Dockerfile"""
-				 }
-			 contextDir = "context"
-			 commandArgs = "--no-cache"
-			 namesAndTags = """
-		teamcity-server:EAP-linux
-		""".trimIndent()
-		}
-		param("dockerImage.platform", "linux")
-		}
-		
-		script {
-			 name = "context teamcity-minimal-agent:EAP-linux"
-			 scriptContent = """
-		echo 2> context/.dockerignore
-		echo TeamCity/webapps >> context/.dockerignore
-		echo TeamCity/devPackage >> context/.dockerignore
-		echo TeamCity/lib >> context/.dockerignore
-		""".trimIndent()
-		}
-		
-		dockerCommand {
-			 name = "build teamcity-minimal-agent:EAP-linux"
-			 commandType = build {
-				 source = file {
-				 path = """context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile"""
-				 }
-			 contextDir = "context"
-			 commandArgs = "--no-cache"
-			 namesAndTags = """
-		teamcity-minimal-agent:EAP-linux
-		""".trimIndent()
-		}
-		param("dockerImage.platform", "linux")
-		}
-		
-		script {
-			 name = "context teamcity-agent:EAP-linux"
-			 scriptContent = """
-		echo 2> context/.dockerignore
-		echo TeamCity >> context/.dockerignore
-		""".trimIndent()
-		}
-		
-		dockerCommand {
-			 name = "build teamcity-agent:EAP-linux"
-			 commandType = build {
-				 source = file {
-				 path = """context/generated/linux/Agent/Ubuntu/20.04/Dockerfile"""
-				 }
-			 contextDir = "context"
-			 commandArgs = "--no-cache"
-			 namesAndTags = """
-		teamcity-agent:EAP-linux
-		""".trimIndent()
-		}
-		param("dockerImage.platform", "linux")
-		}
-		
-		script {
-			 name = "context teamcity-agent:EAP-linux-sudo"
-			 scriptContent = """
-		echo 2> context/.dockerignore
-		echo TeamCity >> context/.dockerignore
-		""".trimIndent()
-		}
-		
-		dockerCommand {
-			 name = "build teamcity-agent:EAP-linux-sudo"
-			 commandType = build {
-				 source = file {
-				 path = """context/generated/linux/Agent/Ubuntu/20.04-sudo/Dockerfile"""
-				 }
-			 contextDir = "context"
-			 commandArgs = "--no-cache"
-			 namesAndTags = """
-		teamcity-agent:EAP-linux-sudo
-		""".trimIndent()
-		}
-		param("dockerImage.platform", "linux")
-		}
-		
-		script {
-			 name = "context teamcity-agent:EAP-linux-arm64"
-			 scriptContent = """
-		echo 2> context/.dockerignore
-		echo TeamCity >> context/.dockerignore
-		""".trimIndent()
-		}
-		
-		dockerCommand {
-			 name = "build teamcity-agent:EAP-linux-arm64"
-			 commandType = build {
-				 source = file {
-				 path = """context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile"""
-				 }
-			 contextDir = "context"
-			 commandArgs = "--no-cache"
-			 namesAndTags = """
-		teamcity-agent:EAP-linux-arm64
-		""".trimIndent()
-		}
-		param("dockerImage.platform", "linux")
-		}
-		
-		script {
-			 name = "context teamcity-agent:EAP-linux-arm64-sudo"
-			 scriptContent = """
-		echo 2> context/.dockerignore
-		echo TeamCity >> context/.dockerignore
-		""".trimIndent()
-		}
-		
-		dockerCommand {
-			 name = "build teamcity-agent:EAP-linux-arm64-sudo"
-			 commandType = build {
-				 source = file {
-				 path = """context/generated/linux/Agent/UbuntuARM/20.04-sudo/Dockerfile"""
-				 }
-			 contextDir = "context"
-			 commandArgs = "--no-cache"
-			 namesAndTags = """
-		teamcity-agent:EAP-linux-arm64-sudo
-		""".trimIndent()
-		}
-		param("dockerImage.platform", "linux")
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-server:EAP-linux"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "teamcity-server:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
-			}
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-minimal-agent:EAP-linux"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "teamcity-minimal-agent:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-			}
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent:EAP-linux"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "teamcity-agent:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-			}
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent:EAP-linux-sudo"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "teamcity-agent:EAP-linux-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-			}
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent:EAP-linux-arm64"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "teamcity-agent:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-			}
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent:EAP-linux-arm64-sudo"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "teamcity-agent:EAP-linux-arm64-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-server:EAP-linux"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-minimal-agent:EAP-linux"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent:EAP-linux"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent:EAP-linux-sudo"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent:EAP-linux-arm64"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent:EAP-linux-arm64-sudo"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-	}
-	features {
-		freeDiskSpace {
-			 requiredSpace = "8gb"
-			 failBuild = true
-		}
-		dockerSupport {
-			 cleanupPushedImages = true
-			 loginToRegistry = on {
-				 dockerRegistryId = "PROJECT_EXT_774"
-			 }
-		}
-		swabra {
-			 forceCleanCheckout = true
-		}
-	}
-	dependencies {
-		 dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
-			 snapshot {
-				 onDependencyFailure = FailureAction.IGNORE
-				 reuseBuilds = ReuseBuilds.ANY
-			 }
-			 artifacts {
-				 artifactRules = "TeamCity.zip!/**=>context/TeamCity"
-			 }
-		 }
-	}
-	params {
-		 param("system.teamcity.agent.ensure.free.space", "8gb")
-	}
-	requirements {
-	}
+script {
+name = "context teamcity-server:EAP-linux"
+scriptContent = """
+echo 2> context/.dockerignore
+echo TeamCity/buildAgent >> context/.dockerignore
+echo TeamCity/temp >> context/.dockerignore
+""".trimIndent()
+}
+
+dockerCommand {
+name = "build teamcity-server:EAP-linux"
+commandType = build {
+source = file {
+path = """context/generated/linux/Server/Ubuntu/20.04/Dockerfile"""
+}
+contextDir = "context"
+commandArgs = "--no-cache"
+namesAndTags = """
+teamcity-server:EAP-linux
+""".trimIndent()
+}
+param("dockerImage.platform", "linux")
+}
+
+script {
+name = "context teamcity-minimal-agent:EAP-linux"
+scriptContent = """
+echo 2> context/.dockerignore
+echo TeamCity/webapps >> context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+""".trimIndent()
+}
+
+dockerCommand {
+name = "build teamcity-minimal-agent:EAP-linux"
+commandType = build {
+source = file {
+path = """context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile"""
+}
+contextDir = "context"
+commandArgs = "--no-cache"
+namesAndTags = """
+teamcity-minimal-agent:EAP-linux
+""".trimIndent()
+}
+param("dockerImage.platform", "linux")
+}
+
+script {
+name = "context teamcity-agent:EAP-linux"
+scriptContent = """
+echo 2> context/.dockerignore
+echo TeamCity >> context/.dockerignore
+""".trimIndent()
+}
+
+dockerCommand {
+name = "build teamcity-agent:EAP-linux"
+commandType = build {
+source = file {
+path = """context/generated/linux/Agent/Ubuntu/20.04/Dockerfile"""
+}
+contextDir = "context"
+commandArgs = "--no-cache"
+namesAndTags = """
+teamcity-agent:EAP-linux
+""".trimIndent()
+}
+param("dockerImage.platform", "linux")
+}
+
+script {
+name = "context teamcity-agent:EAP-linux-sudo"
+scriptContent = """
+echo 2> context/.dockerignore
+echo TeamCity >> context/.dockerignore
+""".trimIndent()
+}
+
+dockerCommand {
+name = "build teamcity-agent:EAP-linux-sudo"
+commandType = build {
+source = file {
+path = """context/generated/linux/Agent/Ubuntu/20.04-sudo/Dockerfile"""
+}
+contextDir = "context"
+commandArgs = "--no-cache"
+namesAndTags = """
+teamcity-agent:EAP-linux-sudo
+""".trimIndent()
+}
+param("dockerImage.platform", "linux")
+}
+
+script {
+name = "context teamcity-agent:EAP-linux-arm64"
+scriptContent = """
+echo 2> context/.dockerignore
+echo TeamCity >> context/.dockerignore
+""".trimIndent()
+}
+
+dockerCommand {
+name = "build teamcity-agent:EAP-linux-arm64"
+commandType = build {
+source = file {
+path = """context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile"""
+}
+contextDir = "context"
+commandArgs = "--no-cache"
+namesAndTags = """
+teamcity-agent:EAP-linux-arm64
+""".trimIndent()
+}
+param("dockerImage.platform", "linux")
+}
+
+script {
+name = "context teamcity-agent:EAP-linux-arm64-sudo"
+scriptContent = """
+echo 2> context/.dockerignore
+echo TeamCity >> context/.dockerignore
+""".trimIndent()
+}
+
+dockerCommand {
+name = "build teamcity-agent:EAP-linux-arm64-sudo"
+commandType = build {
+source = file {
+path = """context/generated/linux/Agent/UbuntuARM/20.04-sudo/Dockerfile"""
+}
+contextDir = "context"
+commandArgs = "--no-cache"
+namesAndTags = """
+teamcity-agent:EAP-linux-arm64-sudo
+""".trimIndent()
+}
+param("dockerImage.platform", "linux")
+}
+
+dockerCommand {
+name = "tag teamcity-server:EAP-linux"
+commandType = other {
+subCommand = "tag"
+commandArgs = "teamcity-server:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-minimal-agent:EAP-linux"
+commandType = other {
+subCommand = "tag"
+commandArgs = "teamcity-minimal-agent:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent:EAP-linux"
+commandType = other {
+subCommand = "tag"
+commandArgs = "teamcity-agent:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent:EAP-linux-sudo"
+commandType = other {
+subCommand = "tag"
+commandArgs = "teamcity-agent:EAP-linux-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent:EAP-linux-arm64"
+commandType = other {
+subCommand = "tag"
+commandArgs = "teamcity-agent:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent:EAP-linux-arm64-sudo"
+commandType = other {
+subCommand = "tag"
+commandArgs = "teamcity-agent:EAP-linux-arm64-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+}
+}
+
+dockerCommand {
+name = "push teamcity-server:EAP-linux"
+commandType = push {
+namesAndTags = """
+%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "push teamcity-minimal-agent:EAP-linux"
+commandType = push {
+namesAndTags = """
+%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent:EAP-linux"
+commandType = push {
+namesAndTags = """
+%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent:EAP-linux-sudo"
+commandType = push {
+namesAndTags = """
+%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent:EAP-linux-arm64"
+commandType = push {
+namesAndTags = """
+%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent:EAP-linux-arm64-sudo"
+commandType = push {
+namesAndTags = """
+%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+}
+features {
+freeDiskSpace {
+requiredSpace = "8gb"
+failBuild = true
+}
+dockerSupport {
+cleanupPushedImages = true
+loginToRegistry = on {
+dockerRegistryId = "PROJECT_EXT_774"
+}
+}
+swabra {
+forceCleanCheckout = true
+}
+}
+dependencies {
+dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
+snapshot { onDependencyFailure = FailureAction.IGNORE
+reuseBuilds = ReuseBuilds.ANY }
+artifacts {
+artifactRules = "TeamCity.zip!/**=>context/TeamCity"
+}
+}
+}
+params {
+param("system.teamcity.agent.ensure.free.space", "8gb")
+}
+requirements {
+}
 })
 

--- a/.teamcity/generated/PushLocalWindows1803.kts
+++ b/.teamcity/generated/PushLocalWindows1803.kts
@@ -1,31 +1,18 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
 object push_local_windows_1803 : BuildType({
-	 name = "ON PAUSE Build and push windows 1803"
-	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-	 description  = "teamcity-server:EAP-nanoserver-1803,EAP teamcity-minimal-agent:EAP-nanoserver-1803,EAP teamcity-agent:EAP-windowsservercore-1803,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1803,EAP"
+name = "ON PAUSE Build and push windows 1803"
+buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+description  = "teamcity-server:EAP-nanoserver-1803,EAP teamcity-minimal-agent:EAP-nanoserver-1803,EAP teamcity-agent:EAP-windowsservercore-1803,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1803,EAP"
 })
 

--- a/.teamcity/generated/PushLocalWindows1809.kts
+++ b/.teamcity/generated/PushLocalWindows1809.kts
@@ -1,265 +1,246 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
 object push_local_windows_1809 : BuildType({
-	 name = "Build and push windows 1809"
-	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-	 description  = "teamcity-server:EAP-nanoserver-1809,EAP teamcity-minimal-agent:EAP-nanoserver-1809,EAP teamcity-agent:EAP-windowsservercore-1809,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1809,EAP"
-	 vcs {
-		 root(TeamCityDockerImagesRepo)
-	 }
+name = "Build and push windows 1809"
+buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+description  = "teamcity-server:EAP-nanoserver-1809,EAP teamcity-minimal-agent:EAP-nanoserver-1809,EAP teamcity-agent:EAP-windowsservercore-1809,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1809,EAP"
+vcs {root(TeamCityDockerImagesRepo)}
+steps {
+dockerCommand {
+name = "pull mcr.microsoft.com/powershell:nanoserver-1809"
+commandType = other {
+subCommand = "pull"
+commandArgs = "mcr.microsoft.com/powershell:nanoserver-1809"
+}
+}
 
- 	 steps {
-		dockerCommand {
-			 name = "pull mcr.microsoft.com/powershell:nanoserver-1809"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "mcr.microsoft.com/powershell:nanoserver-1809"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull mcr.microsoft.com/windows/nanoserver:1809"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "mcr.microsoft.com/windows/nanoserver:1809"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
-			 }
-		}
-		
-		script {
-			 name = "context teamcity-server:EAP-nanoserver-1809"
-			 scriptContent = """
-		echo 2> context/.dockerignore
-		echo TeamCity/buildAgent >> context/.dockerignore
-		echo TeamCity/temp >> context/.dockerignore
-		""".trimIndent()
-		}
-		
-		dockerCommand {
-			 name = "build teamcity-server:EAP-nanoserver-1809"
-			 commandType = build {
-				 source = file {
-				 path = """context/generated/windows/Server/nanoserver/1809/Dockerfile"""
-				 }
-			 contextDir = "context"
-			 commandArgs = "--no-cache"
-			 namesAndTags = """
-		teamcity-server:EAP-nanoserver-1809
-		""".trimIndent()
-		}
-		param("dockerImage.platform", "windows")
-		}
-		
-		script {
-			 name = "context teamcity-minimal-agent:EAP-nanoserver-1809"
-			 scriptContent = """
-		echo 2> context/.dockerignore
-		echo TeamCity/webapps >> context/.dockerignore
-		echo TeamCity/devPackage >> context/.dockerignore
-		echo TeamCity/lib >> context/.dockerignore
-		""".trimIndent()
-		}
-		
-		dockerCommand {
-			 name = "build teamcity-minimal-agent:EAP-nanoserver-1809"
-			 commandType = build {
-				 source = file {
-				 path = """context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile"""
-				 }
-			 contextDir = "context"
-			 commandArgs = "--no-cache"
-			 namesAndTags = """
-		teamcity-minimal-agent:EAP-nanoserver-1809
-		""".trimIndent()
-		}
-		param("dockerImage.platform", "windows")
-		}
-		
-		script {
-			 name = "context teamcity-agent:EAP-windowsservercore-1809"
-			 scriptContent = """
-		echo 2> context/.dockerignore
-		echo TeamCity/webapps >> context/.dockerignore
-		echo TeamCity/devPackage >> context/.dockerignore
-		echo TeamCity/lib >> context/.dockerignore
-		""".trimIndent()
-		}
-		
-		dockerCommand {
-			 name = "build teamcity-agent:EAP-windowsservercore-1809"
-			 commandType = build {
-				 source = file {
-				 path = """context/generated/windows/Agent/windowsservercore/1809/Dockerfile"""
-				 }
-			 contextDir = "context"
-			 commandArgs = "--no-cache"
-			 namesAndTags = """
-		teamcity-agent:EAP-windowsservercore-1809
-		""".trimIndent()
-		}
-		param("dockerImage.platform", "windows")
-		}
-		
-		script {
-			 name = "context teamcity-agent:EAP-nanoserver-1809"
-			 scriptContent = """
-		echo 2> context/.dockerignore
-		echo TeamCity/webapps >> context/.dockerignore
-		echo TeamCity/devPackage >> context/.dockerignore
-		echo TeamCity/lib >> context/.dockerignore
-		""".trimIndent()
-		}
-		
-		dockerCommand {
-			 name = "build teamcity-agent:EAP-nanoserver-1809"
-			 commandType = build {
-				 source = file {
-				 path = """context/generated/windows/Agent/nanoserver/1809/Dockerfile"""
-				 }
-			 contextDir = "context"
-			 commandArgs = "--no-cache"
-			 namesAndTags = """
-		teamcity-agent:EAP-nanoserver-1809
-		""".trimIndent()
-		}
-		param("dockerImage.platform", "windows")
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-server:EAP-nanoserver-1809"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "teamcity-server:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			}
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-minimal-agent:EAP-nanoserver-1809"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "teamcity-minimal-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			}
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent:EAP-windowsservercore-1809"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "teamcity-agent:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
-			}
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent:EAP-nanoserver-1809"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "teamcity-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-server:EAP-nanoserver-1809"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-minimal-agent:EAP-nanoserver-1809"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent:EAP-windowsservercore-1809"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent:EAP-nanoserver-1809"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-	}
-	features {
-		freeDiskSpace {
-			 requiredSpace = "43gb"
-			 failBuild = true
-		}
-		dockerSupport {
-			 cleanupPushedImages = true
-			 loginToRegistry = on {
-				 dockerRegistryId = "PROJECT_EXT_774"
-			 }
-		}
-		swabra {
-			 forceCleanCheckout = true
-		}
-	}
-	dependencies {
-		 dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
-			 snapshot {
-				 onDependencyFailure = FailureAction.IGNORE
-				 reuseBuilds = ReuseBuilds.ANY
-			 }
-			 artifacts {
-				 artifactRules = "TeamCity.zip!/**=>context/TeamCity"
-			 }
-		 }
-	}
-	params {
-		 param("system.teamcity.agent.ensure.free.space", "43gb")
-	}
-	requirements {
-		 contains("system.agent.name", "docker")
-		 contains("system.agent.name", "windows10")
-	}
+dockerCommand {
+name = "pull mcr.microsoft.com/windows/nanoserver:1809"
+commandType = other {
+subCommand = "pull"
+commandArgs = "mcr.microsoft.com/windows/nanoserver:1809"
+}
+}
+
+dockerCommand {
+name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
+commandType = other {
+subCommand = "pull"
+commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
+}
+}
+
+script {
+name = "context teamcity-server:EAP-nanoserver-1809"
+scriptContent = """
+echo 2> context/.dockerignore
+echo TeamCity/buildAgent >> context/.dockerignore
+echo TeamCity/temp >> context/.dockerignore
+""".trimIndent()
+}
+
+dockerCommand {
+name = "build teamcity-server:EAP-nanoserver-1809"
+commandType = build {
+source = file {
+path = """context/generated/windows/Server/nanoserver/1809/Dockerfile"""
+}
+contextDir = "context"
+commandArgs = "--no-cache"
+namesAndTags = """
+teamcity-server:EAP-nanoserver-1809
+""".trimIndent()
+}
+param("dockerImage.platform", "windows")
+}
+
+script {
+name = "context teamcity-minimal-agent:EAP-nanoserver-1809"
+scriptContent = """
+echo 2> context/.dockerignore
+echo TeamCity/webapps >> context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+""".trimIndent()
+}
+
+dockerCommand {
+name = "build teamcity-minimal-agent:EAP-nanoserver-1809"
+commandType = build {
+source = file {
+path = """context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile"""
+}
+contextDir = "context"
+commandArgs = "--no-cache"
+namesAndTags = """
+teamcity-minimal-agent:EAP-nanoserver-1809
+""".trimIndent()
+}
+param("dockerImage.platform", "windows")
+}
+
+script {
+name = "context teamcity-agent:EAP-windowsservercore-1809"
+scriptContent = """
+echo 2> context/.dockerignore
+echo TeamCity/webapps >> context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+""".trimIndent()
+}
+
+dockerCommand {
+name = "build teamcity-agent:EAP-windowsservercore-1809"
+commandType = build {
+source = file {
+path = """context/generated/windows/Agent/windowsservercore/1809/Dockerfile"""
+}
+contextDir = "context"
+commandArgs = "--no-cache"
+namesAndTags = """
+teamcity-agent:EAP-windowsservercore-1809
+""".trimIndent()
+}
+param("dockerImage.platform", "windows")
+}
+
+script {
+name = "context teamcity-agent:EAP-nanoserver-1809"
+scriptContent = """
+echo 2> context/.dockerignore
+echo TeamCity/webapps >> context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+""".trimIndent()
+}
+
+dockerCommand {
+name = "build teamcity-agent:EAP-nanoserver-1809"
+commandType = build {
+source = file {
+path = """context/generated/windows/Agent/nanoserver/1809/Dockerfile"""
+}
+contextDir = "context"
+commandArgs = "--no-cache"
+namesAndTags = """
+teamcity-agent:EAP-nanoserver-1809
+""".trimIndent()
+}
+param("dockerImage.platform", "windows")
+}
+
+dockerCommand {
+name = "tag teamcity-server:EAP-nanoserver-1809"
+commandType = other {
+subCommand = "tag"
+commandArgs = "teamcity-server:EAP-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-minimal-agent:EAP-nanoserver-1809"
+commandType = other {
+subCommand = "tag"
+commandArgs = "teamcity-minimal-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent:EAP-windowsservercore-1809"
+commandType = other {
+subCommand = "tag"
+commandArgs = "teamcity-agent:EAP-windowsservercore-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
+}
+}
+
+dockerCommand {
+name = "tag teamcity-agent:EAP-nanoserver-1809"
+commandType = other {
+subCommand = "tag"
+commandArgs = "teamcity-agent:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
+}
+}
+
+dockerCommand {
+name = "push teamcity-server:EAP-nanoserver-1809"
+commandType = push {
+namesAndTags = """
+%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "push teamcity-minimal-agent:EAP-nanoserver-1809"
+commandType = push {
+namesAndTags = """
+%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent:EAP-windowsservercore-1809"
+commandType = push {
+namesAndTags = """
+%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+dockerCommand {
+name = "push teamcity-agent:EAP-nanoserver-1809"
+commandType = push {
+namesAndTags = """
+%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809
+""".trimIndent()
+removeImageAfterPush = false
+}
+}
+
+}
+features {
+freeDiskSpace {
+requiredSpace = "43gb"
+failBuild = true
+}
+dockerSupport {
+cleanupPushedImages = true
+loginToRegistry = on {
+dockerRegistryId = "PROJECT_EXT_774"
+}
+}
+swabra {
+forceCleanCheckout = true
+}
+}
+dependencies {
+dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
+snapshot { onDependencyFailure = FailureAction.IGNORE
+reuseBuilds = ReuseBuilds.ANY }
+artifacts {
+artifactRules = "TeamCity.zip!/**=>context/TeamCity"
+}
+}
+}
+params {
+param("system.teamcity.agent.ensure.free.space", "43gb")
+}
+requirements {
+contains("teamcity.agent.jvm.os.name", "Windows")
+}
 })
 

--- a/.teamcity/generated/PushLocalWindows1903.kts
+++ b/.teamcity/generated/PushLocalWindows1903.kts
@@ -1,31 +1,18 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
 object push_local_windows_1903 : BuildType({
-	 name = "ON PAUSE Build and push windows 1903"
-	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-	 description  = "teamcity-server:EAP-nanoserver-1903,EAP teamcity-minimal-agent:EAP-nanoserver-1903,EAP teamcity-agent:EAP-windowsservercore-1903,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1903,EAP"
+name = "ON PAUSE Build and push windows 1903"
+buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+description  = "teamcity-server:EAP-nanoserver-1903,EAP teamcity-minimal-agent:EAP-nanoserver-1903,EAP teamcity-agent:EAP-windowsservercore-1903,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1903,EAP"
 })
 

--- a/.teamcity/generated/PushLocalWindows1909.kts
+++ b/.teamcity/generated/PushLocalWindows1909.kts
@@ -1,31 +1,18 @@
-// NOTE: THIS IS AN AUTO-GENERATED FILE. IT HAD BEEN CREATED USING TEAMCITY.DOCKER PROJECT. ...
-// ... IF NEEDED, PLEASE, EDIT DSL GENERATOR RATHER THAN THE FILES DIRECTLY. ... 
-// ... FOR MORE DETAILS, PLEASE, REFER TO DOCUMENTATION WITHIN THE REPOSITORY.
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
 object push_local_windows_1909 : BuildType({
-	 name = "ON PAUSE Build and push windows 1909"
-	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-	 description  = "teamcity-server:EAP-nanoserver-1909,EAP teamcity-minimal-agent:EAP-nanoserver-1909,EAP teamcity-agent:EAP-windowsservercore-1909,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1909,EAP"
+name = "ON PAUSE Build and push windows 1909"
+buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+description  = "teamcity-server:EAP-nanoserver-1909,EAP teamcity-minimal-agent:EAP-nanoserver-1909,EAP teamcity-agent:EAP-windowsservercore-1909,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-1909,EAP"
 })
 

--- a/.teamcity/generated/PushLocalWindowsLtsc2022.kts
+++ b/.teamcity/generated/PushLocalWindowsLtsc2022.kts
@@ -10,38 +10,38 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
 import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
 
-object push_local_windows_2004 : BuildType({
-name = "Build and push windows 2004"
+object push_local_windows_ltsc2022 : BuildType({
+name = "Build and push windows ltsc2022"
 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
-description  = "teamcity-server:EAP-nanoserver-2004,EAP teamcity-minimal-agent:EAP-nanoserver-2004,EAP teamcity-agent:EAP-windowsservercore-2004,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-2004,EAP"
+description  = "teamcity-server:EAP-nanoserver-ltsc2022,EAP teamcity-minimal-agent:EAP-nanoserver-ltsc2022,EAP teamcity-agent:EAP-windowsservercore-ltsc2022,EAP-windowsservercore,-windowsservercore:EAP-nanoserver-ltsc2022,EAP"
 vcs {root(TeamCityDockerImagesRepo)}
 steps {
 dockerCommand {
-name = "pull mcr.microsoft.com/powershell:nanoserver-2004"
+name = "pull mcr.microsoft.com/powershell:nanoserver-ltsc2022"
 commandType = other {
 subCommand = "pull"
-commandArgs = "mcr.microsoft.com/powershell:nanoserver-2004"
+commandArgs = "mcr.microsoft.com/powershell:nanoserver-ltsc2022"
 }
 }
 
 dockerCommand {
-name = "pull mcr.microsoft.com/windows/nanoserver:2004"
+name = "pull mcr.microsoft.com/windows/nanoserver:ltsc2022"
 commandType = other {
 subCommand = "pull"
-commandArgs = "mcr.microsoft.com/windows/nanoserver:2004"
+commandArgs = "mcr.microsoft.com/windows/nanoserver:ltsc2022"
 }
 }
 
 dockerCommand {
-name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
+name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
 commandType = other {
 subCommand = "pull"
-commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
+commandArgs = "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
 }
 }
 
 script {
-name = "context teamcity-server:EAP-nanoserver-2004"
+name = "context teamcity-server:EAP-nanoserver-ltsc2022"
 scriptContent = """
 echo 2> context/.dockerignore
 echo TeamCity/buildAgent >> context/.dockerignore
@@ -50,22 +50,22 @@ echo TeamCity/temp >> context/.dockerignore
 }
 
 dockerCommand {
-name = "build teamcity-server:EAP-nanoserver-2004"
+name = "build teamcity-server:EAP-nanoserver-ltsc2022"
 commandType = build {
 source = file {
-path = """context/generated/windows/Server/nanoserver/2004/Dockerfile"""
+path = """context/generated/windows/Server/nanoserver/ltsc2022/Dockerfile"""
 }
 contextDir = "context"
 commandArgs = "--no-cache"
 namesAndTags = """
-teamcity-server:EAP-nanoserver-2004
+teamcity-server:EAP-nanoserver-ltsc2022
 """.trimIndent()
 }
 param("dockerImage.platform", "windows")
 }
 
 script {
-name = "context teamcity-minimal-agent:EAP-nanoserver-2004"
+name = "context teamcity-minimal-agent:EAP-nanoserver-ltsc2022"
 scriptContent = """
 echo 2> context/.dockerignore
 echo TeamCity/webapps >> context/.dockerignore
@@ -75,22 +75,22 @@ echo TeamCity/lib >> context/.dockerignore
 }
 
 dockerCommand {
-name = "build teamcity-minimal-agent:EAP-nanoserver-2004"
+name = "build teamcity-minimal-agent:EAP-nanoserver-ltsc2022"
 commandType = build {
 source = file {
-path = """context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile"""
+path = """context/generated/windows/MinimalAgent/nanoserver/ltsc2022/Dockerfile"""
 }
 contextDir = "context"
 commandArgs = "--no-cache"
 namesAndTags = """
-teamcity-minimal-agent:EAP-nanoserver-2004
+teamcity-minimal-agent:EAP-nanoserver-ltsc2022
 """.trimIndent()
 }
 param("dockerImage.platform", "windows")
 }
 
 script {
-name = "context teamcity-agent:EAP-windowsservercore-2004"
+name = "context teamcity-agent:EAP-windowsservercore-ltsc2022"
 scriptContent = """
 echo 2> context/.dockerignore
 echo TeamCity/webapps >> context/.dockerignore
@@ -100,22 +100,22 @@ echo TeamCity/lib >> context/.dockerignore
 }
 
 dockerCommand {
-name = "build teamcity-agent:EAP-windowsservercore-2004"
+name = "build teamcity-agent:EAP-windowsservercore-ltsc2022"
 commandType = build {
 source = file {
-path = """context/generated/windows/Agent/windowsservercore/2004/Dockerfile"""
+path = """context/generated/windows/Agent/windowsservercore/ltsc2022/Dockerfile"""
 }
 contextDir = "context"
 commandArgs = "--no-cache"
 namesAndTags = """
-teamcity-agent:EAP-windowsservercore-2004
+teamcity-agent:EAP-windowsservercore-ltsc2022
 """.trimIndent()
 }
 param("dockerImage.platform", "windows")
 }
 
 script {
-name = "context teamcity-agent:EAP-nanoserver-2004"
+name = "context teamcity-agent:EAP-nanoserver-ltsc2022"
 scriptContent = """
 echo 2> context/.dockerignore
 echo TeamCity/webapps >> context/.dockerignore
@@ -125,87 +125,87 @@ echo TeamCity/lib >> context/.dockerignore
 }
 
 dockerCommand {
-name = "build teamcity-agent:EAP-nanoserver-2004"
+name = "build teamcity-agent:EAP-nanoserver-ltsc2022"
 commandType = build {
 source = file {
-path = """context/generated/windows/Agent/nanoserver/2004/Dockerfile"""
+path = """context/generated/windows/Agent/nanoserver/ltsc2022/Dockerfile"""
 }
 contextDir = "context"
 commandArgs = "--no-cache"
 namesAndTags = """
-teamcity-agent:EAP-nanoserver-2004
+teamcity-agent:EAP-nanoserver-ltsc2022
 """.trimIndent()
 }
 param("dockerImage.platform", "windows")
 }
 
 dockerCommand {
-name = "tag teamcity-server:EAP-nanoserver-2004"
+name = "tag teamcity-server:EAP-nanoserver-ltsc2022"
 commandType = other {
 subCommand = "tag"
-commandArgs = "teamcity-server:EAP-nanoserver-2004 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandArgs = "teamcity-server:EAP-nanoserver-ltsc2022 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
 }
 }
 
 dockerCommand {
-name = "tag teamcity-minimal-agent:EAP-nanoserver-2004"
+name = "tag teamcity-minimal-agent:EAP-nanoserver-ltsc2022"
 commandType = other {
 subCommand = "tag"
-commandArgs = "teamcity-minimal-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandArgs = "teamcity-minimal-agent:EAP-nanoserver-ltsc2022 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
 }
 }
 
 dockerCommand {
-name = "tag teamcity-agent:EAP-windowsservercore-2004"
+name = "tag teamcity-agent:EAP-windowsservercore-ltsc2022"
 commandType = other {
 subCommand = "tag"
-commandArgs = "teamcity-agent:EAP-windowsservercore-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
+commandArgs = "teamcity-agent:EAP-windowsservercore-ltsc2022 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-ltsc2022"
 }
 }
 
 dockerCommand {
-name = "tag teamcity-agent:EAP-nanoserver-2004"
+name = "tag teamcity-agent:EAP-nanoserver-ltsc2022"
 commandType = other {
 subCommand = "tag"
-commandArgs = "teamcity-agent:EAP-nanoserver-2004 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+commandArgs = "teamcity-agent:EAP-nanoserver-ltsc2022 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022"
 }
 }
 
 dockerCommand {
-name = "push teamcity-server:EAP-nanoserver-2004"
+name = "push teamcity-server:EAP-nanoserver-ltsc2022"
 commandType = push {
 namesAndTags = """
-%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004
+%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022
 """.trimIndent()
 removeImageAfterPush = false
 }
 }
 
 dockerCommand {
-name = "push teamcity-minimal-agent:EAP-nanoserver-2004"
+name = "push teamcity-minimal-agent:EAP-nanoserver-ltsc2022"
 commandType = push {
 namesAndTags = """
-%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
+%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022
 """.trimIndent()
 removeImageAfterPush = false
 }
 }
 
 dockerCommand {
-name = "push teamcity-agent:EAP-windowsservercore-2004"
+name = "push teamcity-agent:EAP-windowsservercore-ltsc2022"
 commandType = push {
 namesAndTags = """
-%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004
+%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-ltsc2022
 """.trimIndent()
 removeImageAfterPush = false
 }
 }
 
 dockerCommand {
-name = "push teamcity-agent:EAP-nanoserver-2004"
+name = "push teamcity-agent:EAP-nanoserver-ltsc2022"
 commandType = push {
 namesAndTags = """
-%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004
+%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-ltsc2022
 """.trimIndent()
 removeImageAfterPush = false
 }

--- a/configs/windows/Agent/nanoserver/ltsc2022/NanoServer1809.Dockerfile.config
+++ b/configs/windows/Agent/nanoserver/ltsc2022/NanoServer1809.Dockerfile.config
@@ -1,0 +1,8 @@
+windowsBuild=ltsc2022
+tag=nanoserver-${windowsBuild}
+repo=https://hub.docker.com/r/jetbrains/
+# https://hub.docker.com/_/microsoft-powershell
+powershellImage=mcr.microsoft.com/powershell:nanoserver-${windowsBuild}
+# https://hub.docker.com/_/microsoft-windows-nanoserver
+nanoserverImage=mcr.microsoft.com/windows/nanoserver:${windowsBuild}
+teamcityWindowsservercoreImage=teamcity-agent:${versionTag}-windowsservercore-${windowsBuild}

--- a/configs/windows/Agent/windowsservercore/ltsc2022/WindowsServerCore1803.Dockerfile.config
+++ b/configs/windows/Agent/windowsservercore/ltsc2022/WindowsServerCore1803.Dockerfile.config
@@ -1,0 +1,6 @@
+windowsBuild=ltsc2022
+tag=windowsservercore-${windowsBuild}
+repo=https://hub.docker.com/r/jetbrains/
+# https://hub.docker.com/_/microsoft-dotnet-framework-sdk/
+windowsservercoreImage=mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-${windowsBuild}
+teamcityMinimalAgentImage=teamcity-minimal-agent:${versionTag}-nanoserver-${windowsBuild}

--- a/configs/windows/MinimalAgent/nanoserver/ltsc2022/NanoServer1809.Dockerfile.config
+++ b/configs/windows/MinimalAgent/nanoserver/ltsc2022/NanoServer1809.Dockerfile.config
@@ -1,0 +1,7 @@
+windowsBuild=ltsc2022
+tag=nanoserver-${windowsBuild}
+repo=https://hub.docker.com/r/jetbrains/
+# https://hub.docker.com/_/microsoft-powershell
+powershellImage=mcr.microsoft.com/powershell:nanoserver-${windowsBuild}
+# https://hub.docker.com/_/microsoft-windows-nanoserver
+nanoserverImage=mcr.microsoft.com/windows/nanoserver:${windowsBuild}

--- a/configs/windows/Server/nanoserver/ltsc2022/NanoServer1809.Dockerfile.config
+++ b/configs/windows/Server/nanoserver/ltsc2022/NanoServer1809.Dockerfile.config
@@ -1,0 +1,7 @@
+windowsBuild=ltsc2022
+tag=nanoserver-${windowsBuild}
+repo=https://hub.docker.com/r/jetbrains/
+# https://hub.docker.com/_/microsoft-powershell
+powershellImage=mcr.microsoft.com/powershell:nanoserver-${windowsBuild}
+# https://hub.docker.com/_/microsoft-windows-nanoserver
+nanoserverImage=mcr.microsoft.com/windows/nanoserver:${windowsBuild}

--- a/context/generated/teamcity-agent-EAP-nanoserver-ltsc2022.cmd
+++ b/context/generated/teamcity-agent-EAP-nanoserver-ltsc2022.cmd
@@ -1,0 +1,10 @@
+cd ../..
+docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
+docker pull mcr.microsoft.com/powershell:nanoserver-ltsc2022
+docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022
+echo TeamCity/webapps > context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+docker build -f "context/generated/windows/MinimalAgent/nanoserver/ltsc2022/Dockerfile" -t teamcity-minimal-agent:EAP-nanoserver-ltsc2022 "context"
+docker build -f "context/generated/windows/Agent/windowsservercore/ltsc2022/Dockerfile" -t teamcity-agent:EAP-windowsservercore-ltsc2022 "context"
+docker build -f "context/generated/windows/Agent/nanoserver/ltsc2022/Dockerfile" -t teamcity-agent:EAP-nanoserver-ltsc2022 "context"

--- a/context/generated/teamcity-agent-EAP-windowsservercore-ltsc2022.cmd
+++ b/context/generated/teamcity-agent-EAP-windowsservercore-ltsc2022.cmd
@@ -1,0 +1,9 @@
+cd ../..
+docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
+docker pull mcr.microsoft.com/powershell:nanoserver-ltsc2022
+docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022
+echo TeamCity/webapps > context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+docker build -f "context/generated/windows/MinimalAgent/nanoserver/ltsc2022/Dockerfile" -t teamcity-minimal-agent:EAP-nanoserver-ltsc2022 "context"
+docker build -f "context/generated/windows/Agent/windowsservercore/ltsc2022/Dockerfile" -t teamcity-agent:EAP-windowsservercore-ltsc2022 "context"

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -29,6 +29,9 @@ When running an image with multi-architecture support, docker will automatically
 
 #### windows
 
+- ltsc2022
+  - [EAP-nanoserver-ltsc2022](#EAP-nanoserver-ltsc2022)
+  - [EAP-windowsservercore-ltsc2022](#EAP-windowsservercore-ltsc2022)
 - 2004
   - [EAP-nanoserver-2004](#EAP-nanoserver-2004)
   - [EAP-windowsservercore-2004](#EAP-windowsservercore-2004)
@@ -48,7 +51,7 @@ When running an image with multi-architecture support, docker will automatically
 
 ### EAP
 
-Supported platforms: linux 20.04, windows 1809, windows 2004
+Supported platforms: linux 20.04, windows 1809, windows 2004, windows ltsc2022
 
 #### Content
 
@@ -56,15 +59,17 @@ Supported platforms: linux 20.04, windows 1809, windows 2004
 - [EAP-linux-arm64](#EAP-linux-arm64)
 - [EAP-nanoserver-1809](#EAP-nanoserver-1809)
 - [EAP-nanoserver-2004](#EAP-nanoserver-2004)
+- [EAP-nanoserver-ltsc2022](#EAP-nanoserver-ltsc2022)
 
 ### EAP-windowsservercore
 
-Supported platforms: windows 1809, windows 2004
+Supported platforms: windows 1809, windows 2004, windows ltsc2022
 
 #### Content
 
 - [EAP-windowsservercore-1809](#EAP-windowsservercore-1809)
 - [EAP-windowsservercore-2004](#EAP-windowsservercore-2004)
+- [EAP-windowsservercore-ltsc2022](#EAP-windowsservercore-ltsc2022)
 
 
 ### EAP-linux
@@ -272,6 +277,41 @@ docker build -f "context/generated/windows/Agent/nanoserver/2004/Dockerfile" -t 
 
 _The required free space to generate image(s) is about **40 GB**._
 
+### EAP-nanoserver-ltsc2022
+
+[Dockerfile](windows/Agent/nanoserver/ltsc2022/Dockerfile)
+
+This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) build agent image.
+
+The docker image is available on:
+
+- [https://hub.docker.com/r/jetbrains/teamcity-agent](https://hub.docker.com/r/jetbrains/teamcity-agent)
+
+Installed components:
+
+- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
+- [JDK <img align="center" height="18" src="/logo/corretto.png"> Amazon Corretto x64 v.11.0.16.9.1 Checksum (MD5) e46d240031e3a58f6bfbd1f67044da61](https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-windows-x64-jdk.zip)
+- [Git x64 v.2.33.0 Checksum (SHA256) e28968ddd1c928eec233e0c692a90d6ac41eb7b53a9d7a408c13cb5b613afa95](https://github.com/git-for-windows/git/releases/download/v2.33.0.windows.2/MinGit-2.33.0.2-64-bit.zip)
+- [.NET SDK v.6.0.100 x86 Checksum (SHA512) d2fa2f0d2b4550ac3408b924ab356add378af1d0f639623f0742e37f57b3f2b525d81f5d5c029303b6d95fed516b04a7b6c3a98f27f770fc8b4e76414cf41660](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip)
+
+Container platform: windows
+
+Docker build commands:
+
+```
+docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
+docker pull mcr.microsoft.com/powershell:nanoserver-ltsc2022
+docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022
+echo TeamCity/webapps > context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+docker build -f "context/generated/windows/MinimalAgent/nanoserver/ltsc2022/Dockerfile" -t teamcity-minimal-agent:EAP-nanoserver-ltsc2022 "context"
+docker build -f "context/generated/windows/Agent/windowsservercore/ltsc2022/Dockerfile" -t teamcity-agent:EAP-windowsservercore-ltsc2022 "context"
+docker build -f "context/generated/windows/Agent/nanoserver/ltsc2022/Dockerfile" -t teamcity-agent:EAP-nanoserver-ltsc2022 "context"
+```
+
+_The required free space to generate image(s) is about **40 GB**._
+
 ### EAP-windowsservercore-1809
 
 [Dockerfile](windows/Agent/windowsservercore/1809/Dockerfile)
@@ -342,6 +382,43 @@ echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore
 docker build -f "context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile" -t teamcity-minimal-agent:EAP-nanoserver-2004 "context"
 docker build -f "context/generated/windows/Agent/windowsservercore/2004/Dockerfile" -t teamcity-agent:EAP-windowsservercore-2004 "context"
+```
+
+_The required free space to generate image(s) is about **38 GB**._
+
+### EAP-windowsservercore-ltsc2022
+
+[Dockerfile](windows/Agent/windowsservercore/ltsc2022/Dockerfile)
+
+This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) build agent image.
+
+The docker image is available on:
+
+- [https://hub.docker.com/r/jetbrains/teamcity-agent](https://hub.docker.com/r/jetbrains/teamcity-agent)
+
+Installed components:
+
+- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
+- [.NET Runtime v.3.1.21 x86 Checksum (SHA512) 7ba766b2f388ab09beee6a465f1eeb6b9a6858c8b6da51dacc79622b110558ef6211a40e715a16b526f2da08216c99143570b8253ff2c5ad874400475d1feb44](https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.21/dotnet-runtime-3.1.21-win-x64.zip)
+- [.NET Runtime v.5.0.12 x86 Checksum (SHA512) 636f22bfbfd98c80c96f2fc3815beb42ee2699cf2a410eeba24ddcc9304bc39594260eca4061b012d4b02b9c4592fa6927343077df053343a9c344a9289658e1](https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.12/dotnet-runtime-5.0.12-win-x64.zip)
+- [.NET SDK v.6.0.100 x86 Checksum (SHA512) d2fa2f0d2b4550ac3408b924ab356add378af1d0f639623f0742e37f57b3f2b525d81f5d5c029303b6d95fed516b04a7b6c3a98f27f770fc8b4e76414cf41660](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip)
+- [JDK <img align="center" height="18" src="/logo/corretto.png"> Amazon Corretto x64 v.11.0.16.9.1 Checksum (MD5) e46d240031e3a58f6bfbd1f67044da61](https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-windows-x64-jdk.zip)
+- [Git x64 v.2.33.0 Checksum (SHA256) e28968ddd1c928eec233e0c692a90d6ac41eb7b53a9d7a408c13cb5b613afa95](https://github.com/git-for-windows/git/releases/download/v2.33.0.windows.2/MinGit-2.33.0.2-64-bit.zip)
+- [Mercurial x64 v.5.9.1](https://www.mercurial-scm.org/release/windows/mercurial-5.9.1-x64.msi)
+
+Container platform: windows
+
+Docker build commands:
+
+```
+docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
+docker pull mcr.microsoft.com/powershell:nanoserver-ltsc2022
+docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022
+echo TeamCity/webapps > context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+docker build -f "context/generated/windows/MinimalAgent/nanoserver/ltsc2022/Dockerfile" -t teamcity-minimal-agent:EAP-nanoserver-ltsc2022 "context"
+docker build -f "context/generated/windows/Agent/windowsservercore/ltsc2022/Dockerfile" -t teamcity-agent:EAP-windowsservercore-ltsc2022 "context"
 ```
 
 _The required free space to generate image(s) is about **38 GB**._

--- a/context/generated/teamcity-minimal-agent-EAP-nanoserver-ltsc2022.cmd
+++ b/context/generated/teamcity-minimal-agent-EAP-nanoserver-ltsc2022.cmd
@@ -1,0 +1,7 @@
+cd ../..
+docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
+docker pull mcr.microsoft.com/powershell:nanoserver-ltsc2022
+echo TeamCity/webapps > context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+docker build -f "context/generated/windows/MinimalAgent/nanoserver/ltsc2022/Dockerfile" -t teamcity-minimal-agent:EAP-nanoserver-ltsc2022 "context"

--- a/context/generated/teamcity-minimal-agent.md
+++ b/context/generated/teamcity-minimal-agent.md
@@ -22,6 +22,8 @@ When running an image with multi-architecture support, docker will automatically
 
 #### windows
 
+- ltsc2022
+  - [EAP-nanoserver-ltsc2022](#EAP-nanoserver-ltsc2022)
 - 2004
   - [EAP-nanoserver-2004](#EAP-nanoserver-2004)
 - 1909
@@ -36,13 +38,14 @@ When running an image with multi-architecture support, docker will automatically
 
 ### EAP
 
-Supported platforms: linux 20.04, windows 1809, windows 2004
+Supported platforms: linux 20.04, windows 1809, windows 2004, windows ltsc2022
 
 #### Content
 
 - [EAP-linux](#EAP-linux)
 - [EAP-nanoserver-1809](#EAP-nanoserver-1809)
 - [EAP-nanoserver-2004](#EAP-nanoserver-2004)
+- [EAP-nanoserver-ltsc2022](#EAP-nanoserver-ltsc2022)
 
 
 ### EAP-linux
@@ -130,6 +133,36 @@ echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore
 docker build -f "context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile" -t teamcity-minimal-agent:EAP-nanoserver-2004 "context"
+```
+
+_The required free space to generate image(s) is about **10 GB**._
+
+### EAP-nanoserver-ltsc2022
+
+[Dockerfile](windows/MinimalAgent/nanoserver/ltsc2022/Dockerfile)
+
+This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) build agent image.
+
+The docker image is available on:
+
+- [https://hub.docker.com/r/jetbrains/teamcity-minimal-agent](https://hub.docker.com/r/jetbrains/teamcity-minimal-agent)
+
+Installed components:
+
+- [JDK <img align="center" height="18" src="/logo/corretto.png"> Amazon Corretto x64 v.11.0.16.9.1 Checksum (MD5) e46d240031e3a58f6bfbd1f67044da61](https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-windows-x64-jdk.zip)
+- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
+
+Container platform: windows
+
+Docker build commands:
+
+```
+docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
+docker pull mcr.microsoft.com/powershell:nanoserver-ltsc2022
+echo TeamCity/webapps > context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+docker build -f "context/generated/windows/MinimalAgent/nanoserver/ltsc2022/Dockerfile" -t teamcity-minimal-agent:EAP-nanoserver-ltsc2022 "context"
 ```
 
 _The required free space to generate image(s) is about **10 GB**._

--- a/context/generated/teamcity-server-EAP-nanoserver-ltsc2022.cmd
+++ b/context/generated/teamcity-server-EAP-nanoserver-ltsc2022.cmd
@@ -1,0 +1,5 @@
+cd ../..
+docker pull mcr.microsoft.com/powershell:nanoserver-ltsc2022
+echo TeamCity/buildAgent > context/.dockerignore
+echo TeamCity/temp >> context/.dockerignore
+docker build -f "context/generated/windows/Server/nanoserver/ltsc2022/Dockerfile" -t teamcity-server:EAP-nanoserver-ltsc2022 "context"

--- a/context/generated/teamcity-server.md
+++ b/context/generated/teamcity-server.md
@@ -22,6 +22,8 @@ When running an image with multi-architecture support, docker will automatically
 
 #### windows
 
+- ltsc2022
+  - [EAP-nanoserver-ltsc2022](#EAP-nanoserver-ltsc2022)
 - 2004
   - [EAP-nanoserver-2004](#EAP-nanoserver-2004)
 - 1909
@@ -36,13 +38,14 @@ When running an image with multi-architecture support, docker will automatically
 
 ### EAP
 
-Supported platforms: linux 20.04, windows 1809, windows 2004
+Supported platforms: linux 20.04, windows 1809, windows 2004, windows ltsc2022
 
 #### Content
 
 - [EAP-linux](#EAP-linux)
 - [EAP-nanoserver-1809](#EAP-nanoserver-1809)
 - [EAP-nanoserver-2004](#EAP-nanoserver-2004)
+- [EAP-nanoserver-ltsc2022](#EAP-nanoserver-ltsc2022)
 
 
 ### EAP-linux
@@ -129,6 +132,35 @@ docker pull mcr.microsoft.com/powershell:nanoserver-2004
 echo TeamCity/buildAgent > context/.dockerignore
 echo TeamCity/temp >> context/.dockerignore
 docker build -f "context/generated/windows/Server/nanoserver/2004/Dockerfile" -t teamcity-server:EAP-nanoserver-2004 "context"
+```
+
+_The required free space to generate image(s) is about **6 GB**._
+
+### EAP-nanoserver-ltsc2022
+
+[Dockerfile](windows/Server/nanoserver/ltsc2022/Dockerfile)
+
+This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) server image. The image is suitable for production use and evaluation purposes.
+
+The docker image is available on:
+
+- [https://hub.docker.com/r/jetbrains/teamcity-server](https://hub.docker.com/r/jetbrains/teamcity-server)
+
+Installed components:
+
+- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
+- [JDK <img align="center" height="18" src="/logo/corretto.png"> Amazon Corretto x64 v.11.0.16.9.1 Checksum (MD5) e46d240031e3a58f6bfbd1f67044da61](https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-windows-x64-jdk.zip)
+- [Git x64 v.2.33.0 Checksum (SHA256) e28968ddd1c928eec233e0c692a90d6ac41eb7b53a9d7a408c13cb5b613afa95](https://github.com/git-for-windows/git/releases/download/v2.33.0.windows.2/MinGit-2.33.0.2-64-bit.zip)
+
+Container platform: windows
+
+Docker build commands:
+
+```
+docker pull mcr.microsoft.com/powershell:nanoserver-ltsc2022
+echo TeamCity/buildAgent > context/.dockerignore
+echo TeamCity/temp >> context/.dockerignore
+docker build -f "context/generated/windows/Server/nanoserver/ltsc2022/Dockerfile" -t teamcity-server:EAP-nanoserver-ltsc2022 "context"
 ```
 
 _The required free space to generate image(s) is about **6 GB**._

--- a/context/generated/windows/Agent/nanoserver/ltsc2022/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/ltsc2022/Dockerfile
@@ -1,0 +1,83 @@
+# Default arguments
+ARG nanoserverImage='mcr.microsoft.com/windows/nanoserver:ltsc2022'
+ARG powershellImage='mcr.microsoft.com/powershell:nanoserver-ltsc2022'
+ARG teamcityWindowsservercoreImage='teamcity-agent:EAP-windowsservercore-ltsc2022'
+
+# The list of required arguments
+# ARG nanoserverImage
+# ARG powershellImage
+# ARG teamcityWindowsservercoreImage
+
+
+
+FROM ${powershellImage} AS dotnet
+
+COPY scripts/*.cs /scripts/
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ARG teamcityWindowsservercoreImage
+FROM ${teamcityWindowsservercoreImage} AS tools
+
+# Workaround for https://github.com/PowerShell/PowerShell-Docker/issues/164
+ARG nanoserverImage
+FROM ${nanoserverImage}
+
+ENV ProgramFiles="C:\Program Files" \
+    # set a fixed location for the Module analysis cache
+    PSModuleAnalysisCachePath="C:\Users\ContainerUser\AppData\Local\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" \
+    # Persist %PSCORE% ENV variable for user convenience
+    PSCORE="$ProgramFiles\PowerShell\pwsh.exe"
+
+COPY --from=dotnet ["C:/Program Files/PowerShell", "C:/Program Files/PowerShell"]
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;%ProgramFiles%\PowerShell"
+USER ContainerUser
+
+# intialize powershell module cache
+RUN pwsh -NoLogo -NoProfile -Command " \
+    $stopTime = (get-date).AddMinutes(15); \
+    $ErrorActionPreference = 'Stop' ; \
+    $ProgressPreference = 'SilentlyContinue' ; \
+    while(!(Test-Path -Path $env:PSModuleAnalysisCachePath)) {  \
+        Write-Host "'Waiting for $env:PSModuleAnalysisCachePath'" ; \
+        if((get-date) -gt $stopTime) { throw 'timout expired'} \
+        Start-Sleep -Seconds 6 ; \
+    }"
+
+COPY --from=tools ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
+COPY --from=tools ["C:/Program Files/Git", "C:/Program Files/Git"]
+COPY --from=tools ["C:/Program Files/dotnet", "C:/Program Files/dotnet"]
+COPY --from=tools /BuildAgent /BuildAgent
+
+EXPOSE 9090
+
+VOLUME C:/BuildAgent/conf
+
+    # Configuration file for TeamCity agent
+ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
+    # Java home directory
+    JAVA_HOME="C:\Program Files\Java\OpenJDK" \
+    # Opt out of the telemetry feature
+    DOTNET_CLI_TELEMETRY_OPTOUT=true \
+    # Disable first time experience
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    # Configure Kestrel web server to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
+    NUGET_XMLDOC_MODE=skip
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
+USER ContainerUser
+
+# Trigger first run experience by running arbitrary cmd to populate local package cache
+RUN dotnet help
+
+CMD pwsh ./BuildAgent/run-agent.ps1

--- a/context/generated/windows/Agent/windowsservercore/ltsc2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/ltsc2022/Dockerfile
@@ -1,0 +1,108 @@
+# Default arguments
+ARG dotnetWindowsComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100/dotnet-sdk-6.0.100-win-x64.zip'
+ARG dotnetWindowsComponent_31='https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.21/dotnet-runtime-3.1.21-win-x64.zip'
+ARG dotnetWindowsComponent_50='https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.12/dotnet-runtime-5.0.12-win-x64.zip'
+ARG dotnetWindowsComponentSHA512='d2fa2f0d2b4550ac3408b924ab356add378af1d0f639623f0742e37f57b3f2b525d81f5d5c029303b6d95fed516b04a7b6c3a98f27f770fc8b4e76414cf41660'
+ARG dotnetWindowsComponentSHA512_31='7ba766b2f388ab09beee6a465f1eeb6b9a6858c8b6da51dacc79622b110558ef6211a40e715a16b526f2da08216c99143570b8253ff2c5ad874400475d1feb44'
+ARG dotnetWindowsComponentSHA512_50='636f22bfbfd98c80c96f2fc3815beb42ee2699cf2a410eeba24ddcc9304bc39594260eca4061b012d4b02b9c4592fa6927343077df053343a9c344a9289658e1'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.33.0.windows.2/MinGit-2.33.0.2-64-bit.zip'
+ARG gitWindowsComponentSHA256='e28968ddd1c928eec233e0c692a90d6ac41eb7b53a9d7a408c13cb5b613afa95'
+ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-windows-x64-jdk.zip'
+ARG jdkWindowsComponentMD5SUM='e46d240031e3a58f6bfbd1f67044da61'
+ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-5.9.1-x64.msi'
+ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-nanoserver-ltsc2022'
+ARG windowsservercoreImage='mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022'
+
+# The list of required arguments
+# ARG windowsservercoreImage
+# ARG dotnetWindowsComponent
+# ARG dotnetWindowsComponentSHA512
+# ARG dotnetWindowsComponent_31
+# ARG dotnetWindowsComponentSHA512_31
+# ARG dotnetWindowsComponent_50
+# ARG dotnetWindowsComponentSHA512_50
+# ARG jdkWindowsComponent
+# ARG jdkWindowsComponentMD5SUM
+# ARG gitWindowsComponent
+# ARG gitWindowsComponentSHA256
+# ARG mercurialWindowsComponentName
+# ARG teamcityMinimalAgentImage
+
+
+
+FROM ${teamcityMinimalAgentImage} AS buildagent
+
+ARG windowsservercoreImage
+FROM ${windowsservercoreImage}
+
+COPY scripts/*.cs /scripts/
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ARG dotnetWindowsComponent
+ARG dotnetWindowsComponentSHA512
+ARG dotnetWindowsComponent_31
+ARG dotnetWindowsComponentSHA512_31
+ARG dotnetWindowsComponent_50
+ARG dotnetWindowsComponentSHA512_50
+ARG jdkWindowsComponent
+ARG jdkWindowsComponentMD5SUM
+ARG gitWindowsComponent
+ARG gitWindowsComponentSHA256
+ARG mercurialWindowsComponent
+
+RUN [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls11, tls' ; \
+    $code = Get-Content -Path "scripts/Web.cs" -Raw ; \
+    Add-Type -IgnoreWarnings -TypeDefinition "$code" -Language CSharp ; \
+    $downloadScript = [Scripts.Web]::DownloadFiles($Env:jdkWindowsComponent + '#MD5#' + $Env:jdkWindowsComponentMD5SUM, 'jdk.zip', $Env:gitWindowsComponent + '#SHA256#' + $Env:gitWindowsComponentSHA256, 'git.zip', $Env:mercurialWindowsComponent, 'hg.msi', $Env:dotnetWindowsComponent + '#SHA512#' + $Env:dotnetWindowsComponentSHA512, 'dotnet.zip', $Env:dotnetWindowsComponent_31 + '#SHA512#' + $Env:dotnetWindowsComponentSHA512_31, 'dotnet_31.zip', $Env:dotnetWindowsComponent_50 + '#SHA512#' + $Env:dotnetWindowsComponentSHA512_50, 'dotnet_50.zip') ; \
+    Remove-Item -Force -Recurse $Env:ProgramFiles\dotnet; \
+    Expand-Archive dotnet_31.zip -Force -DestinationPath $Env:ProgramFiles\dotnet; \
+    Remove-Item -Force dotnet_31.zip; \
+    Expand-Archive dotnet_50.zip -Force -DestinationPath $Env:ProgramFiles\dotnet; \
+    Remove-Item -Force dotnet_50.zip; \
+    Expand-Archive dotnet.zip -Force -DestinationPath $Env:ProgramFiles\dotnet; \
+    Remove-Item -Force dotnet.zip; \
+    Get-ChildItem -Path $Env:ProgramFiles\dotnet -Include *.lzma -File -Recurse | foreach { $_.Delete()}; \
+    Expand-Archive jdk.zip -DestinationPath $Env:ProgramFiles\Java ; \
+    Get-ChildItem $Env:ProgramFiles\Java | Rename-Item -NewName "OpenJDK" ; \
+    Remove-Item $Env:ProgramFiles\Java\OpenJDK\lib\src.zip -Force ; \
+    Remove-Item -Force jdk.zip ; \
+    $gitPath = $Env:ProgramFiles + '\Git'; \
+    Expand-Archive git.zip -DestinationPath $gitPath ; \
+    Remove-Item -Force git.zip ; \
+    # avoid circular dependencies in gitconfig
+    $gitConfigFile = $gitPath + '\etc\gitconfig'; \
+    $configContent = Get-Content $gitConfigFile; \
+    $configContent = $configContent.Replace('path = C:/Program Files/Git/etc/gitconfig', ''); \
+    Set-Content $gitConfigFile $configContent; \
+    Start-Process msiexec -Wait -ArgumentList /q, /i, hg.msi ; \
+    Remove-Item -Force hg.msi
+
+COPY --from=buildagent /BuildAgent /BuildAgent
+
+EXPOSE 9090
+
+VOLUME C:/BuildAgent/conf
+
+CMD ./BuildAgent/run-agent.ps1
+
+    # Configuration file for TeamCity agent
+ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
+    # Java home directory
+    JAVA_HOME="C:\Program Files\Java\OpenJDK" \
+    # Opt out of the telemetry feature
+    DOTNET_CLI_TELEMETRY_OPTOUT=true \
+    # Disable first time experience
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    # Configure Kestrel web server to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
+    NUGET_XMLDOC_MODE=skip
+
+USER ContainerAdministrator
+RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
+USER ContainerUser

--- a/context/generated/windows/MinimalAgent/nanoserver/ltsc2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/ltsc2022/Dockerfile
@@ -1,0 +1,78 @@
+# Default arguments
+ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-windows-x64-jdk.zip'
+ARG jdkWindowsComponentMD5SUM='e46d240031e3a58f6bfbd1f67044da61'
+ARG nanoserverImage='mcr.microsoft.com/windows/nanoserver:ltsc2022'
+ARG powershellImage='mcr.microsoft.com/powershell:nanoserver-ltsc2022'
+
+# The list of required arguments
+# ARG jdkWindowsComponent
+# ARG jdkWindowsComponentMD5SUM
+# ARG nanoserverImage
+# ARG powershellImage
+
+
+
+FROM ${powershellImage} AS base
+
+COPY scripts/*.cs /scripts/
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Prepare build agent distribution
+COPY TeamCity/buildAgent C:/BuildAgent
+COPY run-agent.ps1 /BuildAgent/run-agent.ps1
+
+ARG jdkWindowsComponent
+ARG jdkWindowsComponentMD5SUM
+
+RUN [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls11, tls' ; \
+    $code = Get-Content -Path "scripts/Web.cs" -Raw ; \
+    Add-Type -IgnoreWarnings -TypeDefinition "$code" -Language CSharp ; \
+    $downloadScript = [Scripts.Web]::DownloadFiles($Env:jdkWindowsComponent + '#MD5#' + $Env:jdkWindowsComponentMD5SUM, 'jdk.zip') ; \
+    iex $downloadScript ; \
+    Expand-Archive jdk.zip -DestinationPath $Env:ProgramFiles\Java ; \
+    Get-ChildItem $Env:ProgramFiles\Java | Rename-Item -NewName "OpenJDK" ; \
+    Remove-Item -Force jdk.zip ; \
+    if (Test-Path '/BuildAgent/system/.teamcity-agent/unpacked-plugins.xml') { (Get-Content '/BuildAgent/system/.teamcity-agent/unpacked-plugins.xml').replace('/', '\\') | Set-Content '/BuildAgent/system/.teamcity-agent/unpacked-plugins.xml' }
+
+# Workaround for https://github.com/PowerShell/PowerShell-Docker/issues/164
+ARG nanoserverImage
+
+FROM ${nanoserverImage}
+
+ENV ProgramFiles="C:\Program Files" \
+    # set a fixed location for the Module analysis cache
+    PSModuleAnalysisCachePath="C:\Users\ContainerUser\AppData\Local\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" \
+    # Persist %PSCORE% ENV variable for user convenience
+    PSCORE="$ProgramFiles\PowerShell\pwsh.exe"
+
+COPY --from=base ["C:/Program Files/PowerShell", "C:/Program Files/PowerShell"]
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;%ProgramFiles%\PowerShell"
+USER ContainerUser
+
+# intialize powershell module cache
+RUN pwsh -NoLogo -NoProfile -Command " \
+    $stopTime = (get-date).AddMinutes(15); \
+    $ErrorActionPreference = 'Stop' ; \
+    $ProgressPreference = 'SilentlyContinue' ; \
+    while(!(Test-Path -Path $env:PSModuleAnalysisCachePath)) {  \
+        Write-Host "'Waiting for $env:PSModuleAnalysisCachePath'" ; \
+        if((get-date) -gt $stopTime) { throw 'timout expired'} \
+        Start-Sleep -Seconds 6 ; \
+    }"
+
+COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
+
+ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+    CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
+
+COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent
+
+VOLUME C:/BuildAgent/conf
+VOLUME C:/BuildAgent/work
+VOLUME C:/BuildAgent/temp
+VOLUME C:/BuildAgent/logs
+
+CMD pwsh ./BuildAgent/run-agent.ps1

--- a/context/generated/windows/Server/nanoserver/ltsc2022/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/ltsc2022/Dockerfile
@@ -1,0 +1,105 @@
+# Default arguments
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.33.0.windows.2/MinGit-2.33.0.2-64-bit.zip'
+ARG gitWindowsComponentSHA256='e28968ddd1c928eec233e0c692a90d6ac41eb7b53a9d7a408c13cb5b613afa95'
+ARG jdkServerWindowsComponent='https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-windows-x64-jdk.zip'
+ARG jdkServerWindowsComponentMD5SUM='e46d240031e3a58f6bfbd1f67044da61'
+ARG nanoserverImage='mcr.microsoft.com/windows/nanoserver:ltsc2022'
+ARG powershellImage='mcr.microsoft.com/powershell:nanoserver-ltsc2022'
+ARG windowsBuild='ltsc2022'
+
+# The list of required arguments
+# ARG powershellImage
+# ARG jdkServerWindowsComponent
+# ARG jdkServerWindowsComponentMD5SUM
+# ARG gitWindowsComponent
+# ARG gitWindowsComponentSHA256
+# ARG windowsBuild
+# ARG powershellImage
+
+
+
+FROM ${powershellImage} AS base
+
+COPY scripts/*.cs /scripts/
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ARG jdkServerWindowsComponent
+ARG jdkServerWindowsComponentMD5SUM
+
+ARG gitWindowsComponent
+ARG gitWindowsComponentSHA256
+
+RUN [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls11, tls' ; \
+    $code = Get-Content -Path "scripts/Web.cs" -Raw ; \
+    Add-Type -IgnoreWarnings -TypeDefinition "$code" -Language CSharp ; \
+    $downloadScript = [Scripts.Web]::DownloadFiles($Env:jdkServerWindowsComponent + '#MD5#' + $Env:jdkServerWindowsComponentMD5SUM, 'jdk.zip', $Env:gitWindowsComponent + '#SHA256#' + $Env:gitWindowsComponentSHA256, 'git.zip') ; \
+    iex $downloadScript ; \
+    Expand-Archive jdk.zip -DestinationPath $Env:ProgramFiles\Java ; \
+    Get-ChildItem $Env:ProgramFiles\Java | Rename-Item -NewName "OpenJDK" ; \
+    Remove-Item -Force jdk.zip ; \
+    Remove-Item $Env:ProgramFiles\Java\OpenJDK\lib\src.zip -Force ; \
+    Expand-Archive git.zip -DestinationPath $Env:ProgramFiles\Git ; \
+    # https://youtrack.jetbrains.com/issue/TW-73017
+    (Get-Content 'C:\Program Files\Git\etc\gitconfig') -replace 'path = C:/Program Files/Git/etc/gitconfig', '' | Set-Content 'C:\Program Files\Git\etc\gitconfig' ; \
+    Remove-Item -Force git.zip
+
+# Prepare TeamCity server distribution
+ARG windowsBuild
+
+COPY TeamCity /TeamCity
+RUN New-Item C:/TeamCity/webapps/ROOT/WEB-INF/DistributionType.txt -type file -force -value "docker-windows-$Env:windowsBuild" | Out-Null
+COPY run-server.ps1 /TeamCity/run-server.ps1
+
+# Workaround for https://github.com/PowerShell/PowerShell-Docker/issues/164
+ARG nanoserverImage
+
+FROM ${nanoserverImage}
+
+ENV ProgramFiles="C:\Program Files" \
+    # set a fixed location for the Module analysis cache
+    PSModuleAnalysisCachePath="C:\Users\ContainerUser\AppData\Local\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" \
+    # Persist %PSCORE% ENV variable for user convenience
+    PSCORE="$ProgramFiles\PowerShell\pwsh.exe"
+
+COPY --from=base ["C:/Program Files/PowerShell", "C:/Program Files/PowerShell"]
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;%ProgramFiles%\PowerShell"
+USER ContainerUser
+
+# intialize powershell module cache
+RUN pwsh -NoLogo -NoProfile -Command " \
+    $stopTime = (get-date).AddMinutes(15); \
+    $ErrorActionPreference = 'Stop' ; \
+    $ProgressPreference = 'SilentlyContinue' ; \
+    while(!(Test-Path -Path $env:PSModuleAnalysisCachePath)) {  \
+        Write-Host "'Waiting for $env:PSModuleAnalysisCachePath'" ; \
+        if((get-date) -gt $stopTime) { throw 'timout expired'} \
+        Start-Sleep -Seconds 6 ; \
+    }"
+
+COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
+COPY --from=base ["C:/Program Files/Git", "C:/Program Files/Git"]
+
+ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+    TEAMCITY_DIST="C:\TeamCity" \
+    CATALINA_TMPDIR="C:\TeamCity\temp" \
+    TEAMCITY_LOGS="C:\TeamCity\logs" \
+    TEAMCITY_DATA_PATH="C:\ProgramData\JetBrains\TeamCity" \
+    TEAMCITY_SERVER_MEM_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=640m"
+
+EXPOSE 8111
+
+COPY --from=base $TEAMCITY_DIST $TEAMCITY_DIST
+
+VOLUME $TEAMCITY_DATA_PATH \
+       $TEAMCITY_LOGS \
+       $CATALINA_TMPDIR
+
+CMD pwsh C:/TeamCity/run-server.ps1
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;%JRE_HOME%\bin;C:\Program Files\Git\cmd"
+USER ContainerUser


### PR DESCRIPTION
Followed [these instructions](https://github.com/JetBrains/teamcity-docker-images#to-amend-current-docker-images-or-to-build-your-custom-docker-images-or-create-a-pull-request) to add support for Windows Server 2022 (ltsc2022). The images are tested.