### PR TITLE
Disable build of ARM-based TeamCity Docker Images within Docker-related build chain

### DIFF
--- a/.teamcity/generated/ImageValidation.kts
+++ b/.teamcity/generated/ImageValidation.kts
@@ -44,8 +44,6 @@ object image_validation: BuildType({
 
 	 val targetImages: HashMap<String, String> = hashMapOf(
 "teamcity-server-EAP-linux" to "%docker.deployRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux", 
-		"teamcity-agent-EAP-linux-arm64-sudo" to "%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo", 
-		"teamcity-agent-EAP-linux-arm64" to "%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64", 
 		"teamcity-agent-EAP-linux" to "%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux", 
 		"teamcity-agent-EAP-linux-sudo" to "%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo", 
 		"teamcity-minimal-agent-EAP-linux" to "%docker.deployRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux", 

--- a/.teamcity/generated/PublishHubVersion.kts
+++ b/.teamcity/generated/PublishHubVersion.kts
@@ -59,7 +59,7 @@ object publish_hub_version: BuildType({
 		 name = "manifest create teamcity-agent:EAP"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP %docker.deployRepository%teamcity-agent:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
+			 commandArgs = "create %docker.deployRepository%teamcity-agent:EAP %docker.deployRepository%teamcity-agent:EAP-linux %docker.deployRepository%teamcity-agent:EAP-nanoserver-1809 %docker.deployRepository%teamcity-agent:EAP-nanoserver-2004"
 		 }
 	}
 	dockerCommand {
@@ -137,8 +137,7 @@ object publish_hub_version: BuildType({
 	requirements {
 		 noLessThanVer("docker.version", "18.05.0")
 		 contains("docker.server.osType", "windows")
-		 contains("system.agent.name", "docker")
-		 contains("system.agent.name", "windows10")
+		 contains("teamcity.agent.jvm.os.name", "Windows 10")
 	}
 	 features {
 		 dockerSupport {

--- a/.teamcity/generated/PublishLocal.kts
+++ b/.teamcity/generated/PublishLocal.kts
@@ -59,7 +59,7 @@ object publish_local: BuildType({
 		 name = "manifest create teamcity-agent:EAP"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
+			 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 		 }
 	}
 	dockerCommand {
@@ -142,8 +142,7 @@ object publish_local: BuildType({
 	requirements {
 		 noLessThanVer("docker.version", "18.05.0")
 		 contains("docker.server.osType", "windows")
-		 contains("system.agent.name", "docker")
-		 contains("system.agent.name", "windows10")
+		 contains("teamcity.agent.jvm.os.name", "Windows 10")
 	}
 	 features {
 		 dockerSupport {

--- a/.teamcity/generated/PushHubLinux.kts
+++ b/.teamcity/generated/PushHubLinux.kts
@@ -28,6 +28,7 @@ object push_hub_linux: BuildType({
 	buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 	 steps {
 		dockerCommand {
+			 
 			 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-linux"
 			 commandType = other {
 				 subCommand = "pull"
@@ -36,6 +37,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-linux"
 			 commandType = other {
 				 subCommand = "tag"
@@ -44,6 +46,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-server%docker.buildImagePostfix%:EAP-linux"
 			 commandType = push {
 				 namesAndTags = """
@@ -54,58 +57,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
-			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo %docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-agent:EAP-linux-arm64-sudo
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
-			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-			 commandType = other {
-				 subCommand = "pull"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-			 }
-		}
-		
-		dockerCommand {
-			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-			 commandType = other {
-				 subCommand = "tag"
-				 commandArgs = "%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64 %docker.deployRepository%teamcity-agent:EAP-linux-arm64"
-			}
-		}
-		
-		dockerCommand {
-			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-			 commandType = push {
-				 namesAndTags = """
-		%docker.deployRepository%teamcity-agent:EAP-linux-arm64
-		""".trimIndent()
-				 removeImageAfterPush = false
-			 }
-		}
-		
-		dockerCommand {
+			 
 			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux"
 			 commandType = other {
 				 subCommand = "pull"
@@ -114,6 +66,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux"
 			 commandType = other {
 				 subCommand = "tag"
@@ -122,6 +75,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux"
 			 commandType = push {
 				 namesAndTags = """
@@ -132,6 +86,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
 			 commandType = other {
 				 subCommand = "pull"
@@ -140,6 +95,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
 			 commandType = other {
 				 subCommand = "tag"
@@ -148,6 +104,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
 			 commandType = push {
 				 namesAndTags = """
@@ -158,6 +115,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
 			 commandType = other {
 				 subCommand = "pull"
@@ -166,6 +124,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
 			 commandType = other {
 				 subCommand = "tag"
@@ -174,6 +133,7 @@ object push_hub_linux: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
 			 commandType = push {
 				 namesAndTags = """
@@ -186,7 +146,7 @@ object push_hub_linux: BuildType({
 	 }
 	 features {
 		 freeDiskSpace {
-		 	 requiredSpace = "6gb"
+		 	 requiredSpace = "4gb"
 		 	 failBuild = true
 		 }
 		 dockerSupport {
@@ -200,7 +160,7 @@ object push_hub_linux: BuildType({
 		 }
 	 }
 	params {
-		 param("system.teamcity.agent.ensure.free.space", "6gb")
+		 param("system.teamcity.agent.ensure.free.space", "4gb")
 	}
 	 requirements {
 	 	 contains("docker.server.osType", "linux")

--- a/.teamcity/generated/PushHubWindows.kts
+++ b/.teamcity/generated/PushHubWindows.kts
@@ -28,6 +28,7 @@ object push_hub_windows: BuildType({
 	buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
 	 steps {
 		dockerCommand {
+			 
 			 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
 			 commandType = other {
 				 subCommand = "pull"
@@ -36,6 +37,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
 			 commandType = other {
 				 subCommand = "tag"
@@ -44,6 +46,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-1809"
 			 commandType = push {
 				 namesAndTags = """
@@ -54,6 +57,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
 			 commandType = other {
 				 subCommand = "pull"
@@ -62,6 +66,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
 			 commandType = other {
 				 subCommand = "tag"
@@ -70,6 +75,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-1809"
 			 commandType = push {
 				 namesAndTags = """
@@ -80,6 +86,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
 			 commandType = other {
 				 subCommand = "pull"
@@ -88,6 +95,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
 			 commandType = other {
 				 subCommand = "tag"
@@ -96,6 +104,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
 			 commandType = push {
 				 namesAndTags = """
@@ -106,6 +115,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
 			 commandType = other {
 				 subCommand = "pull"
@@ -114,6 +124,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
 			 commandType = other {
 				 subCommand = "tag"
@@ -122,6 +133,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-1809"
 			 commandType = push {
 				 namesAndTags = """
@@ -132,6 +144,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
 			 commandType = other {
 				 subCommand = "pull"
@@ -140,6 +153,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
 			 commandType = other {
 				 subCommand = "tag"
@@ -148,6 +162,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-server%docker.buildImagePostfix%:EAP-nanoserver-2004"
 			 commandType = push {
 				 namesAndTags = """
@@ -158,6 +173,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
 			 commandType = other {
 				 subCommand = "pull"
@@ -166,6 +182,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
 			 commandType = other {
 				 subCommand = "tag"
@@ -174,6 +191,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-windowsservercore-2004"
 			 commandType = push {
 				 namesAndTags = """
@@ -184,6 +202,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 			 commandType = other {
 				 subCommand = "pull"
@@ -192,6 +211,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 			 commandType = other {
 				 subCommand = "tag"
@@ -200,6 +220,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 			 commandType = push {
 				 namesAndTags = """
@@ -210,6 +231,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 			 commandType = other {
 				 subCommand = "pull"
@@ -218,6 +240,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 			 commandType = other {
 				 subCommand = "tag"
@@ -226,6 +249,7 @@ object push_hub_windows: BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-minimal-agent%docker.buildImagePostfix%:EAP-nanoserver-2004"
 			 commandType = push {
 				 namesAndTags = """
@@ -256,13 +280,13 @@ object push_hub_windows: BuildType({
 	}
 	 requirements {
 	 	 contains("docker.server.osType", "windows")
-	 	 contains("system.agent.name", "docker")
-	 	 contains("system.agent.name", "windows10")
+	 	 contains("teamcity.agent.jvm.os.name", "Windows 10")
 	 }
-	dependencies {
-		snapshot(PublishLocal.publish_local) {
-			onDependencyFailure =  FailureAction.FAIL_TO_START 
-		}
-	}
+		 dependencies {
+			 snapshot(PublishLocal.publish_local) {
+
+				 onDependencyFailure =  FailureAction.FAIL_TO_START 
+ 		 }
+		 }
 })
 

--- a/.teamcity/generated/PushLocalLinux2004.kts
+++ b/.teamcity/generated/PushLocalLinux2004.kts
@@ -24,317 +24,335 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object push_local_linux_20_04 : BuildType({
-    name = "Build and push linux 20.04"
-    buildNumberPattern = "%dockerImage.teamcity.buildNumber%-%build.counter%"
-    description =
-        "teamcity-server:EAP-linux,EAP teamcity-minimal-agent:EAP-linux,EAP teamcity-agent:EAP-linux,EAP:EAP-linux-sudo:EAP-linux-arm64,EAP:EAP-linux-arm64-sudo"
-    vcs {
-        root(TeamCityDockerImagesRepo)
-    }
+	 name = "Build and push linux 20.04"
+	 buildNumberPattern="%dockerImage.teamcity.buildNumber%-%build.counter%"
+	 description  = "teamcity-server:EAP-linux,EAP teamcity-minimal-agent:EAP-linux,EAP teamcity-agent:EAP-linux,EAP:EAP-linux-sudo:EAP-linux-arm64,EAP:EAP-linux-arm64-sudo"
+	 vcs {
+		 root(TeamCityDockerImagesRepo)
+	 }
 
-    steps {
-        dockerCommand {
-            name = "pull ubuntu:20.04"
-            commandType = other {
-                subCommand = "pull"
-                commandArgs = "ubuntu:20.04"
-            }
-        }
-
-        script {
-            name = "context teamcity-server:EAP-linux"
-            scriptContent = """
+ 	 steps {
+		dockerCommand {
+			 
+			 name = "pull ubuntu:20.04"
+			 commandType = other {
+				 subCommand = "pull"
+				 commandArgs = "ubuntu:20.04"
+			 }
+		}
+		
+		script {
+			
+			 name = "context teamcity-server:EAP-linux"
+			 scriptContent = """
 		echo 2> context/.dockerignore
 		echo TeamCity/buildAgent >> context/.dockerignore
 		echo TeamCity/temp >> context/.dockerignore
 		""".trimIndent()
-        }
-
-        dockerCommand {
-            name = "build teamcity-server:EAP-linux"
-            commandType = build {
-                source = file {
-                    path = """context/generated/linux/Server/Ubuntu/20.04/Dockerfile"""
-                }
-                contextDir = "context"
-                commandArgs = "--no-cache"
-                namesAndTags = """
+		}
+		
+		dockerCommand {
+		
+			 name = "build teamcity-server:EAP-linux"
+			 commandType = build {
+				 source = file {
+					 path = """context/generated/linux/Server/Ubuntu/20.04/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
 		teamcity-server:EAP-linux
 		""".trimIndent()
-            }
-            param("dockerImage.platform", "linux")
-        }
-
-        script {
-            name = "context teamcity-minimal-agent:EAP-linux"
-            scriptContent = """
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		script {
+			
+			 name = "context teamcity-minimal-agent:EAP-linux"
+			 scriptContent = """
 		echo 2> context/.dockerignore
 		echo TeamCity/webapps >> context/.dockerignore
 		echo TeamCity/devPackage >> context/.dockerignore
 		echo TeamCity/lib >> context/.dockerignore
 		""".trimIndent()
-        }
-
-        dockerCommand {
-            name = "build teamcity-minimal-agent:EAP-linux"
-            commandType = build {
-                source = file {
-                    path = """context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile"""
-                }
-                contextDir = "context"
-                commandArgs = "--no-cache"
-                namesAndTags = """
+		}
+		
+		dockerCommand {
+		
+			 name = "build teamcity-minimal-agent:EAP-linux"
+			 commandType = build {
+				 source = file {
+					 path = """context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
 		teamcity-minimal-agent:EAP-linux
 		""".trimIndent()
-            }
-            param("dockerImage.platform", "linux")
-        }
-
-        script {
-            name = "context teamcity-agent:EAP-linux"
-            scriptContent = """
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		script {
+			
+			 name = "context teamcity-agent:EAP-linux"
+			 scriptContent = """
 		echo 2> context/.dockerignore
 		echo TeamCity >> context/.dockerignore
 		""".trimIndent()
-        }
-
-        dockerCommand {
-            name = "build teamcity-agent:EAP-linux"
-            commandType = build {
-                source = file {
-                    path = """context/generated/linux/Agent/Ubuntu/20.04/Dockerfile"""
-                }
-                contextDir = "context"
-                commandArgs = "--no-cache"
-                namesAndTags = """
+		}
+		
+		dockerCommand {
+		
+			 name = "build teamcity-agent:EAP-linux"
+			 commandType = build {
+				 source = file {
+					 path = """context/generated/linux/Agent/Ubuntu/20.04/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
 		teamcity-agent:EAP-linux
 		""".trimIndent()
-            }
-            param("dockerImage.platform", "linux")
-        }
-
-        script {
-            name = "context teamcity-agent:EAP-linux-sudo"
-            scriptContent = """
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		script {
+			
+			 name = "context teamcity-agent:EAP-linux-sudo"
+			 scriptContent = """
 		echo 2> context/.dockerignore
 		echo TeamCity >> context/.dockerignore
 		""".trimIndent()
-        }
-
-        dockerCommand {
-            name = "build teamcity-agent:EAP-linux-sudo"
-            commandType = build {
-                source = file {
-                    path = """context/generated/linux/Agent/Ubuntu/20.04-sudo/Dockerfile"""
-                }
-                contextDir = "context"
-                commandArgs = "--no-cache"
-                namesAndTags = """
+		}
+		
+		dockerCommand {
+		
+			 name = "build teamcity-agent:EAP-linux-sudo"
+			 commandType = build {
+				 source = file {
+					 path = """context/generated/linux/Agent/Ubuntu/20.04-sudo/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
 		teamcity-agent:EAP-linux-sudo
 		""".trimIndent()
-            }
-            param("dockerImage.platform", "linux")
-        }
-
-        script {
-            name = "context teamcity-agent:EAP-linux-arm64"
-            scriptContent = """
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		script {
+			// ARM-based images are currently not supported by TeamCity 
+			enabled = false
+			 name = "context teamcity-agent:EAP-linux-arm64"
+			 scriptContent = """
 		echo 2> context/.dockerignore
 		echo TeamCity >> context/.dockerignore
 		""".trimIndent()
-            enabled = false
-        }
-
-        dockerCommand {
-            name = "build teamcity-agent:EAP-linux-arm64"
-            commandType = build {
-                source = file {
-                    path = """context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile"""
-                }
-                contextDir = "context"
-                commandArgs = "--no-cache"
-                namesAndTags = """
+		}
+		
+		dockerCommand {
+		// ARM-based images are currently not supported by TeamCity 
+			enabled = false
+			 name = "build teamcity-agent:EAP-linux-arm64"
+			 commandType = build {
+				 source = file {
+					 path = """context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
 		teamcity-agent:EAP-linux-arm64
 		""".trimIndent()
-            }
-            enabled = false
-            param("dockerImage.platform", "linux")
-        }
-
-        script {
-            name = "context teamcity-agent:EAP-linux-arm64-sudo"
-            scriptContent = """
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		script {
+			// ARM-based images are currently not supported by TeamCity 
+			enabled = false
+			 name = "context teamcity-agent:EAP-linux-arm64-sudo"
+			 scriptContent = """
 		echo 2> context/.dockerignore
 		echo TeamCity >> context/.dockerignore
 		""".trimIndent()
+		}
+		
+		dockerCommand {
+		// ARM-based images are currently not supported by TeamCity 
 			enabled = false
-        }
-
-        dockerCommand {
-            name = "build teamcity-agent:EAP-linux-arm64-sudo"
-            commandType = build {
-                source = file {
-                    path = """context/generated/linux/Agent/UbuntuARM/20.04-sudo/Dockerfile"""
-                }
-                contextDir = "context"
-                commandArgs = "--no-cache"
-                namesAndTags = """
+			 name = "build teamcity-agent:EAP-linux-arm64-sudo"
+			 commandType = build {
+				 source = file {
+					 path = """context/generated/linux/Agent/UbuntuARM/20.04-sudo/Dockerfile"""
+				 }
+			 contextDir = "context"
+			 commandArgs = "--no-cache"
+			 namesAndTags = """
 		teamcity-agent:EAP-linux-arm64-sudo
 		""".trimIndent()
-            }
-            param("dockerImage.platform", "linux")
+		}
+		param("dockerImage.platform", "linux")
+		}
+		
+		dockerCommand {
+			
+			 name = "tag teamcity-server:EAP-linux"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-server:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
+			}
+		}
+		
+		dockerCommand {
+			
+			 name = "tag teamcity-minimal-agent:EAP-linux"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-minimal-agent:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
+			}
+		}
+		
+		dockerCommand {
+			
+			 name = "tag teamcity-agent:EAP-linux"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
+			}
+		}
+		
+		dockerCommand {
+			
+			 name = "tag teamcity-agent:EAP-linux-sudo"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-linux-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
+			}
+		}
+		
+		dockerCommand {
+			// ARM-based images are currently not supported by TeamCity 
 			enabled = false
-        }
-
-        dockerCommand {
-            name = "tag teamcity-server:EAP-linux"
-            commandType = other {
-                subCommand = "tag"
-                commandArgs =
-                    "teamcity-server:EAP-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux"
-            }
-        }
-
-        dockerCommand {
-            name = "tag teamcity-minimal-agent:EAP-linux"
-            commandType = other {
-                subCommand = "tag"
-                commandArgs =
-                    "teamcity-minimal-agent:EAP-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux"
-            }
-        }
-
-        dockerCommand {
-            name = "tag teamcity-agent:EAP-linux"
-            commandType = other {
-                subCommand = "tag"
-                commandArgs =
-                    "teamcity-agent:EAP-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux"
-            }
-        }
-
-        dockerCommand {
-            name = "tag teamcity-agent:EAP-linux-sudo"
-            commandType = other {
-                subCommand = "tag"
-                commandArgs =
-                    "teamcity-agent:EAP-linux-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo"
-            }
-        }
-
-        dockerCommand {
-            name = "tag teamcity-agent:EAP-linux-arm64"
-            commandType = other {
-                subCommand = "tag"
-                commandArgs =
-                    "teamcity-agent:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
-            }
+			 name = "tag teamcity-agent:EAP-linux-arm64"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64"
+			}
+		}
+		
+		dockerCommand {
+			// ARM-based images are currently not supported by TeamCity 
 			enabled = false
-        }
-
-        dockerCommand {
-            name = "tag teamcity-agent:EAP-linux-arm64-sudo"
-            commandType = other {
-                subCommand = "tag"
-                commandArgs =
-                    "teamcity-agent:EAP-linux-arm64-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
-            }
-			enabled = false
-        }
-
-        dockerCommand {
-            name = "push teamcity-server:EAP-linux"
-            commandType = push {
-                namesAndTags = """
+			 name = "tag teamcity-agent:EAP-linux-arm64-sudo"
+			 commandType = other {
+				 subCommand = "tag"
+				 commandArgs = "teamcity-agent:EAP-linux-arm64-sudo %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo"
+			}
+		}
+		
+		dockerCommand {
+			 
+			 name = "push teamcity-server:EAP-linux"
+			 commandType = push {
+				 namesAndTags = """
 		%docker.buildRepository%teamcity-server%docker.buildImagePostfix%:EAP-linux
 		""".trimIndent()
-                removeImageAfterPush = false
-            }
-        }
-
-        dockerCommand {
-            name = "push teamcity-minimal-agent:EAP-linux"
-            commandType = push {
-                namesAndTags = """
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 
+			 name = "push teamcity-minimal-agent:EAP-linux"
+			 commandType = push {
+				 namesAndTags = """
 		%docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:EAP-linux
 		""".trimIndent()
-                removeImageAfterPush = false
-            }
-        }
-
-        dockerCommand {
-            name = "push teamcity-agent:EAP-linux"
-            commandType = push {
-                namesAndTags = """
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 
+			 name = "push teamcity-agent:EAP-linux"
+			 commandType = push {
+				 namesAndTags = """
 		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux
 		""".trimIndent()
-                removeImageAfterPush = false
-            }
-        }
-
-        dockerCommand {
-            name = "push teamcity-agent:EAP-linux-sudo"
-            commandType = push {
-                namesAndTags = """
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 
+			 name = "push teamcity-agent:EAP-linux-sudo"
+			 commandType = push {
+				 namesAndTags = """
 		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-sudo
 		""".trimIndent()
-                removeImageAfterPush = false
-            }
-        }
-
-        dockerCommand {
-            name = "push teamcity-agent:EAP-linux-arm64"
-            commandType = push {
-                namesAndTags = """
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 // ARM-based images are currently not supported by TeamCity 
+			enabled = false
+			 name = "push teamcity-agent:EAP-linux-arm64"
+			 commandType = push {
+				 namesAndTags = """
 		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64
 		""".trimIndent()
-                removeImageAfterPush = false
-            }
+				 removeImageAfterPush = false
+			 }
+		}
+		
+		dockerCommand {
+			 // ARM-based images are currently not supported by TeamCity 
 			enabled = false
-        }
-
-        dockerCommand {
-            name = "push teamcity-agent:EAP-linux-arm64-sudo"
-            commandType = push {
-                namesAndTags = """
+			 name = "push teamcity-agent:EAP-linux-arm64-sudo"
+			 commandType = push {
+				 namesAndTags = """
 		%docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:EAP-linux-arm64-sudo
 		""".trimIndent()
-                removeImageAfterPush = false
-            }
-			enabled = false
-        }
-
-    }
-    features {
-        freeDiskSpace {
-            requiredSpace = "8gb"
-            failBuild = true
-        }
-        dockerSupport {
-            cleanupPushedImages = true
-            loginToRegistry = on {
-                dockerRegistryId = "PROJECT_EXT_774,PROJECT_EXT_315"
-            }
-        }
-        swabra {
-            forceCleanCheckout = true
-        }
-    }
-    dependencies {
-        dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
-            snapshot {
-                onDependencyFailure = FailureAction.IGNORE
-                reuseBuilds = ReuseBuilds.ANY
-            }
-            artifacts {
-                artifactRules = "TeamCity.zip!/**=>context/TeamCity"
-            }
-        }
-    }
-    params {
-        param("system.teamcity.agent.ensure.free.space", "8gb")
-    }
-    requirements {
-    }
+				 removeImageAfterPush = false
+			 }
+		}
+		
+	}
+	features {
+		freeDiskSpace {
+			 requiredSpace = "8gb"
+			 failBuild = true
+		}
+		dockerSupport {
+			 cleanupPushedImages = true
+			 loginToRegistry = on {
+				 dockerRegistryId = "PROJECT_EXT_774"
+			 }
+		}
+		swabra {
+			 forceCleanCheckout = true
+		}
+	}
+	dependencies {
+		 dependency(AbsoluteId("TC_Trunk_BuildDistDocker")) {
+			 snapshot {
+				 onDependencyFailure = FailureAction.IGNORE
+				 reuseBuilds = ReuseBuilds.ANY
+			 }
+			 artifacts {
+				 artifactRules = "TeamCity.zip!/**=>context/TeamCity"
+			 }
+		 }
+	}
+	params {
+		 param("system.teamcity.agent.ensure.free.space", "8gb")
+	}
+	requirements {
+	}
 })
 

--- a/.teamcity/generated/PushLocalWindows1809.kts
+++ b/.teamcity/generated/PushLocalWindows1809.kts
@@ -33,6 +33,7 @@ object push_local_windows_1809 : BuildType({
 
  	 steps {
 		dockerCommand {
+			 
 			 name = "pull mcr.microsoft.com/powershell:nanoserver-1809"
 			 commandType = other {
 				 subCommand = "pull"
@@ -41,6 +42,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull mcr.microsoft.com/windows/nanoserver:1809"
 			 commandType = other {
 				 subCommand = "pull"
@@ -49,6 +51,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
 			 commandType = other {
 				 subCommand = "pull"
@@ -57,6 +60,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		script {
+			
 			 name = "context teamcity-server:EAP-nanoserver-1809"
 			 scriptContent = """
 		echo 2> context/.dockerignore
@@ -66,10 +70,11 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+		
 			 name = "build teamcity-server:EAP-nanoserver-1809"
 			 commandType = build {
 				 source = file {
-				 path = """context/generated/windows/Server/nanoserver/1809/Dockerfile"""
+					 path = """context/generated/windows/Server/nanoserver/1809/Dockerfile"""
 				 }
 			 contextDir = "context"
 			 commandArgs = "--no-cache"
@@ -81,6 +86,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		script {
+			
 			 name = "context teamcity-minimal-agent:EAP-nanoserver-1809"
 			 scriptContent = """
 		echo 2> context/.dockerignore
@@ -91,10 +97,11 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+		
 			 name = "build teamcity-minimal-agent:EAP-nanoserver-1809"
 			 commandType = build {
 				 source = file {
-				 path = """context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile"""
+					 path = """context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile"""
 				 }
 			 contextDir = "context"
 			 commandArgs = "--no-cache"
@@ -106,6 +113,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		script {
+			
 			 name = "context teamcity-agent:EAP-windowsservercore-1809"
 			 scriptContent = """
 		echo 2> context/.dockerignore
@@ -116,10 +124,11 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+		
 			 name = "build teamcity-agent:EAP-windowsservercore-1809"
 			 commandType = build {
 				 source = file {
-				 path = """context/generated/windows/Agent/windowsservercore/1809/Dockerfile"""
+					 path = """context/generated/windows/Agent/windowsservercore/1809/Dockerfile"""
 				 }
 			 contextDir = "context"
 			 commandArgs = "--no-cache"
@@ -131,6 +140,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		script {
+			
 			 name = "context teamcity-agent:EAP-nanoserver-1809"
 			 scriptContent = """
 		echo 2> context/.dockerignore
@@ -141,10 +151,11 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+		
 			 name = "build teamcity-agent:EAP-nanoserver-1809"
 			 commandType = build {
 				 source = file {
-				 path = """context/generated/windows/Agent/nanoserver/1809/Dockerfile"""
+					 path = """context/generated/windows/Agent/nanoserver/1809/Dockerfile"""
 				 }
 			 contextDir = "context"
 			 commandArgs = "--no-cache"
@@ -156,6 +167,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-server:EAP-nanoserver-1809"
 			 commandType = other {
 				 subCommand = "tag"
@@ -164,6 +176,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-minimal-agent:EAP-nanoserver-1809"
 			 commandType = other {
 				 subCommand = "tag"
@@ -172,6 +185,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-agent:EAP-windowsservercore-1809"
 			 commandType = other {
 				 subCommand = "tag"
@@ -180,6 +194,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-agent:EAP-nanoserver-1809"
 			 commandType = other {
 				 subCommand = "tag"
@@ -188,6 +203,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-server:EAP-nanoserver-1809"
 			 commandType = push {
 				 namesAndTags = """
@@ -198,6 +214,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-minimal-agent:EAP-nanoserver-1809"
 			 commandType = push {
 				 namesAndTags = """
@@ -208,6 +225,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-agent:EAP-windowsservercore-1809"
 			 commandType = push {
 				 namesAndTags = """
@@ -218,6 +236,7 @@ object push_local_windows_1809 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-agent:EAP-nanoserver-1809"
 			 commandType = push {
 				 namesAndTags = """
@@ -258,8 +277,7 @@ object push_local_windows_1809 : BuildType({
 		 param("system.teamcity.agent.ensure.free.space", "43gb")
 	}
 	requirements {
-		 contains("system.agent.name", "docker")
-		 contains("system.agent.name", "windows10")
+		 contains("teamcity.agent.jvm.os.name", "Windows 10")
 	}
 })
 

--- a/.teamcity/generated/PushLocalWindows2004.kts
+++ b/.teamcity/generated/PushLocalWindows2004.kts
@@ -33,6 +33,7 @@ object push_local_windows_2004 : BuildType({
 
  	 steps {
 		dockerCommand {
+			 
 			 name = "pull mcr.microsoft.com/powershell:nanoserver-2004"
 			 commandType = other {
 				 subCommand = "pull"
@@ -41,6 +42,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull mcr.microsoft.com/windows/nanoserver:2004"
 			 commandType = other {
 				 subCommand = "pull"
@@ -49,6 +51,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004"
 			 commandType = other {
 				 subCommand = "pull"
@@ -57,6 +60,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		script {
+			
 			 name = "context teamcity-server:EAP-nanoserver-2004"
 			 scriptContent = """
 		echo 2> context/.dockerignore
@@ -66,10 +70,11 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+		
 			 name = "build teamcity-server:EAP-nanoserver-2004"
 			 commandType = build {
 				 source = file {
-				 path = """context/generated/windows/Server/nanoserver/2004/Dockerfile"""
+					 path = """context/generated/windows/Server/nanoserver/2004/Dockerfile"""
 				 }
 			 contextDir = "context"
 			 commandArgs = "--no-cache"
@@ -81,6 +86,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		script {
+			
 			 name = "context teamcity-minimal-agent:EAP-nanoserver-2004"
 			 scriptContent = """
 		echo 2> context/.dockerignore
@@ -91,10 +97,11 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+		
 			 name = "build teamcity-minimal-agent:EAP-nanoserver-2004"
 			 commandType = build {
 				 source = file {
-				 path = """context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile"""
+					 path = """context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile"""
 				 }
 			 contextDir = "context"
 			 commandArgs = "--no-cache"
@@ -106,6 +113,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		script {
+			
 			 name = "context teamcity-agent:EAP-windowsservercore-2004"
 			 scriptContent = """
 		echo 2> context/.dockerignore
@@ -116,10 +124,11 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+		
 			 name = "build teamcity-agent:EAP-windowsservercore-2004"
 			 commandType = build {
 				 source = file {
-				 path = """context/generated/windows/Agent/windowsservercore/2004/Dockerfile"""
+					 path = """context/generated/windows/Agent/windowsservercore/2004/Dockerfile"""
 				 }
 			 contextDir = "context"
 			 commandArgs = "--no-cache"
@@ -131,6 +140,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		script {
+			
 			 name = "context teamcity-agent:EAP-nanoserver-2004"
 			 scriptContent = """
 		echo 2> context/.dockerignore
@@ -141,10 +151,11 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+		
 			 name = "build teamcity-agent:EAP-nanoserver-2004"
 			 commandType = build {
 				 source = file {
-				 path = """context/generated/windows/Agent/nanoserver/2004/Dockerfile"""
+					 path = """context/generated/windows/Agent/nanoserver/2004/Dockerfile"""
 				 }
 			 contextDir = "context"
 			 commandArgs = "--no-cache"
@@ -156,6 +167,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-server:EAP-nanoserver-2004"
 			 commandType = other {
 				 subCommand = "tag"
@@ -164,6 +176,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-minimal-agent:EAP-nanoserver-2004"
 			 commandType = other {
 				 subCommand = "tag"
@@ -172,6 +185,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-agent:EAP-windowsservercore-2004"
 			 commandType = other {
 				 subCommand = "tag"
@@ -180,6 +194,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+			
 			 name = "tag teamcity-agent:EAP-nanoserver-2004"
 			 commandType = other {
 				 subCommand = "tag"
@@ -188,6 +203,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-server:EAP-nanoserver-2004"
 			 commandType = push {
 				 namesAndTags = """
@@ -198,6 +214,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-minimal-agent:EAP-nanoserver-2004"
 			 commandType = push {
 				 namesAndTags = """
@@ -208,6 +225,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-agent:EAP-windowsservercore-2004"
 			 commandType = push {
 				 namesAndTags = """
@@ -218,6 +236,7 @@ object push_local_windows_2004 : BuildType({
 		}
 		
 		dockerCommand {
+			 
 			 name = "push teamcity-agent:EAP-nanoserver-2004"
 			 commandType = push {
 				 namesAndTags = """
@@ -258,8 +277,7 @@ object push_local_windows_2004 : BuildType({
 		 param("system.teamcity.agent.ensure.free.space", "43gb")
 	}
 	requirements {
-		 contains("system.agent.name", "docker")
-		 contains("system.agent.name", "windows10")
+		 contains("teamcity.agent.jvm.os.name", "Windows 10")
 	}
 })
 

--- a/tool/TeamCity.Docker/GenerateCommand.cs
+++ b/tool/TeamCity.Docker/GenerateCommand.cs
@@ -35,6 +35,8 @@ namespace TeamCity.Docker
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _configurationExplorer = configurationExplorer ?? throw new ArgumentNullException(nameof(configurationExplorer));
             _buildGraphFactory = buildGraphFactory ?? throw new ArgumentNullException(nameof(buildGraphFactory));
+            
+            // -- Kotlin DSL generators, Script Generators, README files generators
             _generators = generators ?? throw new ArgumentNullException(nameof(generators));
         }
 


### PR DESCRIPTION
As of January of 2023 (`2022.10.x` and earlier releases), TeamCity does not officially support the deployment on ARM-based processors.
The current repository provides Dockerfiles for the build of Docker images compatible with ARM architecture, which users could create for experimental purposes. While we would keep the related manifests within the repository, we would like to exclude the process of building and publishing such images from the build chain defined via Kotlin DSL until the official support is introduced.