### PR TITLE
Move Docker Image into validation even if OS sub-version does not match

### DIFF
--- a/tool/automation/framework/README.md
+++ b/tool/automation/framework/README.md
@@ -15,6 +15,16 @@ The application could be built using Gradle Wrapper.
 ```
 ./gradlew <option> --args="<parameters>"
 ```
+Example:
+```
+./gradlew clean build run --args="validate jetbrains/teamcity-agent:2022.10.2-windowsservercore-2004"
+...
+##teamcity[buildStatisticValue key='SIZE-teamcity-agent:windowsservercore-2004' value='5066342155']
+jetbrains/teamcity-agent:2022.10.2-windowsservercore-2004-windows-10.0.19041.1415-amd64: 
+	 - Original size: 5066342155 (jetbrains/teamcity-agent:2022.10.2-windowsservercore-2004)
+	 - Previous size: 5067986140 (2022.10.1-windowsservercore-2004)
+	 - Percentage change: 0.03% (max allowable - 5.0%)
+```
 
 ### 3.1 Available Options
 


### PR DESCRIPTION
Currently, automation framework skips validation of Docker Image in case it wouldn't be able to guarantee the images were built for the same platform.
```
jetbrains/teamcity-agent-staging:2022.10.2-windowsservercore-1809 - found previous image - 2022.10.1-windowsservercore-1809, but OS version is different - 10.0.17763.3887 and 10.0.17763.3650
```

While we would want to retain the warning message mentioned above, that'd be useful for us to still check it, since that would cover situations when base image had been changed, especially in case of Windows.