### PR TITLE
[2022.10.x] Upgrade Perforce package version: 2022.2-2369846 -> 2022.2-2407422

### DIFF
--- a/configs/linux.config
+++ b/configs/linux.config
@@ -46,5 +46,5 @@ containerdIoLinuxComponentVersion=1.4.12-1
 
 # https://www.perforce.com/perforce-packages
 # https://package.perforce.com/apt/ubuntu/dists/focal/release/binary-amd64/Packages
-p4Version=2022.2-2369846
-p4Name=Perforce Helix Core client (p4) [2022.2-2369846](https://www.perforce.com/products/helix-core)
+p4Version=2022.2-2407422
+p4Name=Perforce Helix Core client (p4) [2022.2-2407422](https://www.perforce.com/products/helix-core)

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -11,7 +11,7 @@ ARG dotnetLinuxComponentSHA512_31='cc4b2fef46e94df88bf0fc11cb15439e79bd48da52456
 ARG dotnetLinuxComponentSHA512_50='32b5f86db3b1d4c21e3cf616d22f0e4a7374385dac0cf03cdebf3520dcf846460d9677ec1829a180920740a0237d64f6eaa2421d036a67f4fe9fb15d4f6b1db9'
 ARG gitLFSLinuxComponentVersion='2.3.4-1'
 ARG gitLinuxComponentVersion='1:2.39.1-0ppa1~ubuntu18.04.1'
-ARG p4Version='2022.2-2369846'
+ARG p4Version='2022.2-2407422'
 ARG repo=''
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:2022.10.2-linux-18.04'
 

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -11,7 +11,7 @@ ARG dotnetLinuxComponentSHA512_31='cc4b2fef46e94df88bf0fc11cb15439e79bd48da52456
 ARG dotnetLinuxComponentSHA512_50='32b5f86db3b1d4c21e3cf616d22f0e4a7374385dac0cf03cdebf3520dcf846460d9677ec1829a180920740a0237d64f6eaa2421d036a67f4fe9fb15d4f6b1db9'
 ARG gitLFSLinuxComponentVersion='2.9.2-1'
 ARG gitLinuxComponentVersion='1:2.39.1-0ppa1~ubuntu20.04.1'
-ARG p4Version='2022.2-2369846'
+ARG p4Version='2022.2-2407422'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:2022.10.2-linux'
 

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -3,7 +3,7 @@ ARG gitLFSLinuxComponentVersion='2.3.4-1'
 ARG gitLinuxComponentVersion='1:2.39.1-0ppa1~ubuntu18.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='6ff46b39cbaec4218fd49c6c64077c43'
-ARG p4Version='2022.2-2369846'
+ARG p4Version='2022.2-2407422'
 ARG repo=''
 ARG ubuntuImage='ubuntu:18.04'
 

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -3,7 +3,7 @@ ARG gitLFSLinuxComponentVersion='2.9.2-1'
 ARG gitLinuxComponentVersion='1:2.39.1-0ppa1~ubuntu20.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='6ff46b39cbaec4218fd49c6c64077c43'
-ARG p4Version='2022.2-2369846'
+ARG p4Version='2022.2-2407422'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG ubuntuImage='ubuntu:20.04'
 

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -104,7 +104,7 @@ Installed components:
 - Git v.2.39.1
 - Git LFS v.2.9.2
 - Mercurial
-- Perforce Helix Core client (p4) [2022.2-2369846](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2407422](https://www.perforce.com/products/helix-core)
 - [Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12), [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET Runtime v.3.1.21 x86 Checksum (SHA512) cc4b2fef46e94df88bf0fc11cb15439e79bd48da524561dffde80d3cd6db218133468ad2f6785803cf0c13f000d95ff71eb258cec76dd8eb809676ec1cb38fac](https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.21/dotnet-runtime-3.1.21-linux-x64.tar.gz)
@@ -380,7 +380,7 @@ Installed components:
 - Git v.2.39.1
 - Git LFS v.2.3.4
 - Mercurial
-- Perforce Helix Core client (p4) [2022.2-2369846](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2407422](https://www.perforce.com/products/helix-core)
 - [Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12), [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET Runtime v.3.1.21 x86 Checksum (SHA512) cc4b2fef46e94df88bf0fc11cb15439e79bd48da524561dffde80d3cd6db218133468ad2f6785803cf0c13f000d95ff71eb258cec76dd8eb809676ec1cb38fac](https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.21/dotnet-runtime-3.1.21-linux-x64.tar.gz)

--- a/context/generated/teamcity-server.md
+++ b/context/generated/teamcity-server.md
@@ -71,7 +71,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/logo/corretto.png"> Amazon Corretto x64 v.11.0.16.9.1 Checksum (MD5) 6ff46b39cbaec4218fd49c6c64077c43](https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-linux-x64.tar.gz)
 - Git v.2.39.1
 - Git LFS v.2.9.2
-- Perforce Helix Core client (p4) [2022.2-2369846](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2407422](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 
@@ -156,7 +156,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/logo/corretto.png"> Amazon Corretto x64 v.11.0.16.9.1 Checksum (MD5) 6ff46b39cbaec4218fd49c6c64077c43](https://corretto.aws/downloads/resources/11.0.16.9.1/amazon-corretto-11.0.16.9.1-linux-x64.tar.gz)
 - Git v.2.39.1
 - Git LFS v.2.3.4
-- Perforce Helix Core client (p4) [2022.2-2369846](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2407422](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 


### PR DESCRIPTION
Pull requests corresponds to [TW-79803 Update Perforce Package version (2022.2-2369846) within TeamCity Docker Images](https://youtrack.jetbrains.com/issue/TW-79803/Update-Perforce-Package-version-2022.2-2369846-within-TeamCity-Docker-Images).

The version of Perforce packages used within TeamCity Docker Images - `2022.2-2369846` - had been deprecated and removed from package registry on February 15th, 2023.
```
15:21:46   Reading state information...
15:21:46   E: Version '2022.2-2369846~focal' for 'helix-cli-base' was not found
15:21:46   E: Version '2022.2-2369846~focal' for 'helix-cli' was not found
```

This pull request introduces changes aimed at bumping up to a newer version of the affected package - `2022.2-2369846` -> `2022.2-2407422`, release on February 15th, 2023. 
Details (ref.: [Perforce Software Release Index](https://www.perforce.com/support/software-release-index)):
```
2023/02/15 Patch for Helix Core, Helix Broker, and Helix Proxy 2022.2/2407422
```
