### PR TITLE
[Windows 18.09-based build of images] Handle "Access to path is denied" exception.

### DIFF
--- a/.teamcity/hosted/scheduled/build/TeamCityScheduledImageBuildWindows.kts
+++ b/.teamcity/hosted/scheduled/build/TeamCityScheduledImageBuildWindows.kts
@@ -105,4 +105,9 @@ object TeamCityScheduledImageBuildWindows : BuildType({
             }
         }
     }
+
+    // An implicit Windoiws 10 requirement has been added in order to prevent DotNet's WebClient internal exception.
+    requirements {
+        contains("teamcity.agent.jvm.os.name", "Windows 10")
+    }
 })


### PR DESCRIPTION
During the build of Windows 18.09-based images, we use C#'s `WebClient` in order to download the required files, specifically: JDK, Git and other archives.
Throughout this process, the following exception might occur:
```
...
 An exception occurred during a WebClient request.
 Access to the path 'C:\jdk.zip' is denied.
 jdk.zip  attempt #7   after 10s
 jdk.zip  abort
```
The ` Access to the path is denied` exception is relatively misleading. It could occur due to the following reasons:
1. **Permissions**. The user that executes the script doesn't have write permissions. It's not our case, as the base image we're using doesn't have a separate `root` user, thus write access is granted.
2. **File permissions**. Target file is either locked, or sub-folders does not exist, or host's filesystem doesn't have enough disk space. It's not our case, as it's possible to manually create the file via DotNet SDK, as well as the target file (e.g. `jdk.zip`) isn't held by any other process.
3. **Network settings**. The download itself could be blocked by network settings, such as FireWall or Anti-Virus.

In order to prevent such issue, the scheduled build of Windows-based images have been appended with the requirement for `Windows 10` host, which doesn't block the download from the used resources.