### PR TITLE
Set -euxE and pipefail for context sh scripts

### DIFF
--- a/context/run-agent-services.sh
+++ b/context/run-agent-services.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -euxE
+set -o pipefail
+
 echo '/run-services.sh'
 
 for entry in /services/*.sh

--- a/context/run-agent.sh
+++ b/context/run-agent.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -euxE
+set -o pipefail
+
 check() {
    if [[ $? != 0 ]]; then
       echo "Error! Stopping the script."

--- a/context/run-docker.sh
+++ b/context/run-docker.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -euxE
+set -o pipefail
+
+
 if [ "$DOCKER_IN_DOCKER" = "start" ] ; then
 
  # Do cover the case when the container is restarted:

--- a/context/run-server-services.sh
+++ b/context/run-server-services.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+
 # Fail if one of the service scripts fail
-set -e
+set -euxE
+set -o pipefail
 
 echo '/run-services.sh'
 

--- a/context/run-server.sh
+++ b/context/run-server.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -euxE
+set -o pipefail
+
 # Setting default values if variables not present
 : ${TEAMCITY_DIST:=/opt/teamcity}
 : ${TEAMCITY_LOGS:=${TEAMCITY_DIST}/logs}


### PR DESCRIPTION
- `eu` ensures that scripts fail in case errors or undefined variables.
- `pipefail` option to ensure that piped commands also exit on failures.
- `x` will print commands before execution
- `E` can be used to inherit error traps (not sure if it's needed here specifically, but I think it's OK to include it as well)

Currently failing to start a service like docker will not stop agent container from proceeding further, for example. This PR should hopefully fix those cases.