### PR TITLE
Re-order the queue of building images within automated scheduled build (Windows)

### DIFF
--- a/.teamcity/generated/ImageValidation.kts
+++ b/.teamcity/generated/ImageValidation.kts
@@ -8,7 +8,6 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
-import hosted.BuildAndPushHosted
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
@@ -23,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object image_validation: BuildType({
 	 name = "Validation of Size Regression - Staging Docker Images (Windows / Linux)"
@@ -100,19 +100,19 @@ object image_validation: BuildType({
 		   dockerSupport {
 			     cleanupPushedImages = true
 			     loginToRegistry = on {
-			       dockerRegistryId = "PROJECT_EXT_774"
+			       dockerRegistryId = "PROJECT_EXT_774,PROJECT_EXT_315"
 			     }
 		   }
 	 }
 
-	dependencies {
-		// Dependency on the build of the Docker image
-		dependency(BuildAndPushHosted.BuildAndPushHosted) {
-			snapshot {
-				onDependencyFailure = FailureAction.FAIL_TO_START
-				reuseBuilds = ReuseBuilds.SUCCESSFUL
-			}
-		}
+	 dependencies {
+	 // Dependency on the build of the Docker image
+		 dependency(BuildAndPushHosted.BuildAndPushHosted) {
+			 snapshot {
+				 onDependencyFailure = FailureAction.FAIL_TO_START
+				 reuseBuilds = ReuseBuilds.SUCCESSFUL
+			 }
+		 }
 	}
 })
 

--- a/.teamcity/generated/ImageValidation.kts
+++ b/.teamcity/generated/ImageValidation.kts
@@ -8,6 +8,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
+import hosted.BuildAndPushHosted
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
@@ -103,5 +104,15 @@ object image_validation: BuildType({
 			     }
 		   }
 	 }
+
+	dependencies {
+		// Dependency on the build of the Docker image
+		dependency(BuildAndPushHosted.BuildAndPushHosted) {
+			snapshot {
+				onDependencyFailure = FailureAction.FAIL_TO_START
+				reuseBuilds = ReuseBuilds.SUCCESSFUL
+			}
+		}
+	}
 })
 

--- a/.teamcity/hosted/scheduled/build/TeamCityScheduledImageBuildWindows.kts
+++ b/.teamcity/hosted/scheduled/build/TeamCityScheduledImageBuildWindows.kts
@@ -26,48 +26,54 @@ object TeamCityScheduledImageBuildWindows : BuildType({
     val images = LinkedList(
         listOf(
             // Windows 18.09
-            DockerImageInfo(
-                "teamcity-server",
-                "EAP-nanoserver-1809",
-                "context/generated/windows/Server/nanoserver/1809/Dockerfile"
-            ),
+            // -- Windows 18.09 minimal agents
             DockerImageInfo(
                 "teamcity-minimal-agent",
                 "EAP-nanoserver-1809",
                 "context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile"
             ),
-            DockerImageInfo(
-                "teamcity-agent",
-                "EAP-nanoserver-1809",
-                "context/generated/windows/Agent/nanoserver/1809/Dockerfile"
-            ),
-            // -- WindowsServerCore image is based on NanoServer image
+            // -- Windows 18.09 core, build based on Minimal Agents
             DockerImageInfo(
                 "teamcity-agent",
                 "EAP-windowsservercore-1809",
                 "context/generated/windows/Agent/windowsservercore/1809/Dockerfile"
             ),
+            DockerImageInfo(
+                "teamcity-agent",
+                "EAP-windowsservercore-2004",
+                "context/generated/windows/Agent/windowsservercore/2004/Dockerfile"
+            ),
+            // -- 18.09 NanoServer, build based on 18.09 Windows Server Core Agents
+            DockerImageInfo(
+                "teamcity-agent",
+                "EAP-nanoserver-1809",
+                "context/generated/windows/Agent/nanoserver/1809/Dockerfile"
+            ),
+            DockerImageInfo(
+                "teamcity-server",
+                "EAP-nanoserver-1809",
+                "context/generated/windows/Server/nanoserver/1809/Dockerfile"
+            ),
+
 
             // Windows 20.04
+            // -- Windows 20.04 minimal agent
+            DockerImageInfo(
+                "teamcity-minimal-agent",
+                "EAP-nanoserver-2004",
+                "context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile"
+            ),
+
+            // -- Windows 20.04 nanoservers
             DockerImageInfo(
                 "teamcity-server",
                 "EAP-nanoserver-2004",
                 "context/generated/windows/Server/nanoserver/2004/Dockerfile"
             ),
             DockerImageInfo(
-                "teamcity-minimal-agent",
-                "EAP-nanoserver-2004",
-                "context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile"
-            ),
-            DockerImageInfo(
                 "teamcity-agent",
                 "EAP-nanoserver-2004",
                 "context/generated/windows/Agent/nanoserver/2004/Dockerfile"
-            ),
-            DockerImageInfo(
-                "teamcity-agent",
-                "EAP-windowsservercore-2004",
-                "context/generated/windows/Agent/windowsservercore/2004/Dockerfile"
             )
         )
     )

--- a/tool/TeamCity.Docker/TeamCityKotlinSettingsGenerator.cs
+++ b/tool/TeamCity.Docker/TeamCityKotlinSettingsGenerator.cs
@@ -235,6 +235,8 @@ namespace TeamCity.Docker
                 "import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger",
                 "import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger",
                 "import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs",
+                // -- Build Configurations
+                "import hosted.BuildAndPushHosted",
 
                 string.Empty
             };
@@ -472,10 +474,22 @@ namespace TeamCity.Docker
                 "\t\t   dockerSupport {",
                 "\t\t\t     cleanupPushedImages = true",
                 "\t\t\t     loginToRegistry = on {",
-                "\t\t\t       dockerRegistryId = \"PROJECT_EXT_774\"",
+                "\t\t\t       dockerRegistryId = \"PROJECT_EXT_774,PROJECT_EXT_315\"",
                 "\t\t\t     }",
                 "\t\t   }",
                 "\t }"
+            );
+
+            yield return String.Join('\n',
+               	"\n\t dependencies {",
+               	"\t // Dependency on the build of the Docker image",
+               	"\t\t dependency(BuildAndPushHosted.BuildAndPushHosted) {",
+               	"\t\t\t snapshot {",
+               	"\t\t\t\t onDependencyFailure = FailureAction.FAIL_TO_START",
+               	"\t\t\t\t reuseBuilds = ReuseBuilds.SUCCESSFUL",
+               	"\t\t\t }",
+               	"\t\t }",
+               	"\t}"
             );
 
             yield return "})";


### PR DESCRIPTION
The pull request is dedicated to changing the order for the build of Windows 1809 based TeamCity Docker images in order to prevent potential dependency issues.