### PR TITLE
Replace JRE references with JDK @ NanoServer Images

### DIFF
--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1803.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1803.Dockerfile
@@ -40,7 +40,7 @@ FROM ${nanoserverImage}
 
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
@@ -72,7 +72,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent

--- a/configs/windows/Server/nanoserver/NanoServer1803.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer1803.Dockerfile
@@ -26,10 +26,10 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 ARG jdkServerWindowsComponent
 
 RUN [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls11, tls' ; \
-    Invoke-WebRequest $Env:jdkServerWindowsComponent -OutFile jre.zip; \
-    Expand-Archive jre.zip -DestinationPath $Env:ProgramFiles\Java ; \
+    Invoke-WebRequest $Env:jdkServerWindowsComponent -OutFile jdk.zip; \
+    Expand-Archive jdk.zip -DestinationPath $Env:ProgramFiles\Java ; \
     Get-ChildItem $Env:ProgramFiles\Java | Rename-Item -NewName "OpenJDK" ; \
-    Remove-Item -Force jre.zip ; \
+    Remove-Item -Force jdk.zip ; \
     Remove-Item $Env:ProgramFiles\Java\OpenJDK\lib\src.zip -Force
 
 # Install [${gitWindowsComponentName}](${gitWindowsComponent})
@@ -54,7 +54,7 @@ FROM ${powershellImage}
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 COPY --from=base ["C:/Program Files/Git", "C:/Program Files/Git"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     TEAMCITY_DIST="C:\TeamCity" \
     TEAMCITY_ENV=container \
     CATALINA_TMPDIR="C:\TeamCity\temp" \
@@ -75,5 +75,5 @@ CMD pwsh C:/TeamCity/run-server.ps1
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;%JRE_HOME%\bin;C:\Program Files\Git\cmd"
+RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
 USER ContainerUser

--- a/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
@@ -86,7 +86,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 COPY --from=base ["C:/Program Files/Git", "C:/Program Files/Git"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     TEAMCITY_DIST="C:\TeamCity" \
     TEAMCITY_ENV=container \
     CATALINA_TMPDIR="C:\TeamCity\temp" \
@@ -106,5 +106,5 @@ CMD pwsh C:/TeamCity/run-server.ps1
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;%JRE_HOME%\bin;C:\Program Files\Git\cmd"
+RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
 USER ContainerUser

--- a/context/generated/windows/MinimalAgent/nanoserver/1803/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1803/Dockerfile
@@ -33,7 +33,7 @@ FROM ${nanoserverImage}
 
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent

--- a/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
@@ -65,7 +65,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent

--- a/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
@@ -65,7 +65,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent

--- a/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
@@ -65,7 +65,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent

--- a/context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile
@@ -65,7 +65,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent

--- a/context/generated/windows/Server/nanoserver/1803/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1803/Dockerfile
@@ -21,10 +21,10 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 ARG jdkServerWindowsComponent
 
 RUN [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls11, tls' ; \
-    Invoke-WebRequest $Env:jdkServerWindowsComponent -OutFile jre.zip; \
-    Expand-Archive jre.zip -DestinationPath $Env:ProgramFiles\Java ; \
+    Invoke-WebRequest $Env:jdkServerWindowsComponent -OutFile jdk.zip; \
+    Expand-Archive jdk.zip -DestinationPath $Env:ProgramFiles\Java ; \
     Get-ChildItem $Env:ProgramFiles\Java | Rename-Item -NewName "OpenJDK" ; \
-    Remove-Item -Force jre.zip ; \
+    Remove-Item -Force jdk.zip ; \
     Remove-Item $Env:ProgramFiles\Java\OpenJDK\lib\src.zip -Force
 
 ARG gitWindowsComponent
@@ -48,7 +48,7 @@ FROM ${powershellImage}
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 COPY --from=base ["C:/Program Files/Git", "C:/Program Files/Git"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     TEAMCITY_DIST="C:\TeamCity" \
     TEAMCITY_ENV=container \
     CATALINA_TMPDIR="C:\TeamCity\temp" \
@@ -69,5 +69,5 @@ CMD pwsh C:/TeamCity/run-server.ps1
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;%JRE_HOME%\bin;C:\Program Files\Git\cmd"
+RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
 USER ContainerUser

--- a/context/generated/windows/Server/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1809/Dockerfile
@@ -82,7 +82,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 COPY --from=base ["C:/Program Files/Git", "C:/Program Files/Git"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     TEAMCITY_DIST="C:\TeamCity" \
     TEAMCITY_ENV=container \
     CATALINA_TMPDIR="C:\TeamCity\temp" \
@@ -102,5 +102,5 @@ CMD pwsh C:/TeamCity/run-server.ps1
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;%JRE_HOME%\bin;C:\Program Files\Git\cmd"
+RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
 USER ContainerUser

--- a/context/generated/windows/Server/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1903/Dockerfile
@@ -82,7 +82,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 COPY --from=base ["C:/Program Files/Git", "C:/Program Files/Git"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     TEAMCITY_DIST="C:\TeamCity" \
     TEAMCITY_ENV=container \
     CATALINA_TMPDIR="C:\TeamCity\temp" \
@@ -102,5 +102,5 @@ CMD pwsh C:/TeamCity/run-server.ps1
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;%JRE_HOME%\bin;C:\Program Files\Git\cmd"
+RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
 USER ContainerUser

--- a/context/generated/windows/Server/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1909/Dockerfile
@@ -82,7 +82,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 COPY --from=base ["C:/Program Files/Git", "C:/Program Files/Git"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     TEAMCITY_DIST="C:\TeamCity" \
     TEAMCITY_ENV=container \
     CATALINA_TMPDIR="C:\TeamCity\temp" \
@@ -102,5 +102,5 @@ CMD pwsh C:/TeamCity/run-server.ps1
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;%JRE_HOME%\bin;C:\Program Files\Git\cmd"
+RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
 USER ContainerUser

--- a/context/generated/windows/Server/nanoserver/2004/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/2004/Dockerfile
@@ -82,7 +82,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 COPY --from=base ["C:/Program Files/Java/OpenJDK", "C:/Program Files/Java/OpenJDK"]
 COPY --from=base ["C:/Program Files/Git", "C:/Program Files/Git"]
 
-ENV JRE_HOME="C:\Program Files\Java\OpenJDK" \
+ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     TEAMCITY_DIST="C:\TeamCity" \
     TEAMCITY_ENV=container \
     CATALINA_TMPDIR="C:\TeamCity\temp" \
@@ -102,5 +102,5 @@ CMD pwsh C:/TeamCity/run-server.ps1
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;%JRE_HOME%\bin;C:\Program Files\Git\cmd"
+RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
 USER ContainerUser

--- a/context/scripts/Program.cs
+++ b/context/scripts/Program.cs
@@ -4,13 +4,10 @@
     {
         public static void Main()
         {
+            // Download JDK archive to include it into the Docker Containers during the build time.
              Web.DownloadFiles(
                  @"https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip#MD5#feb7eab99c647a0b4347be9f0a3276de",
-                 @"jdk.zip",
-                 // TODO: Replace mentions of JRE within NanoServer Docker manifests with JDK, which is actually used, given ...
-                 // ... missing Amazon Corretto's JRE 17 for Windows within official releases for Windows.
-                 @"https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip#MD5#feb7eab99c647a0b4347be9f0a3276de",
-                 @"jre.zip");
+                 @"jdk.zip");
         }
     }
 }


### PR DESCRIPTION
Java Runtime within TeamCity Docker Images is being updated.
* Windows NanoServer Images: [Amazon Corretto JRE 8.252.09.2](https://corretto.aws/downloads/resources/8.252.09.2/amazon-corretto-8.252.09.2-windows-x64-jre.zip) -> [Amazon Corretto JDK 17.0.7.7.1](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip#MD5#feb7eab99c647a0b4347be9f0a3276de)
* The rest of the images (Linux, Windows Core):  [Amazon Corretto JDK 11.0.9.11.2](https://corretto.aws/downloads/resources/11.0.9.11.2/amazon-corretto-11.0.9.11.2-windows-x64-jdk.zip#MD5#9757ebcd8094b4d7040886b2c98bcf37) -> [Amazon Corretto JDK 17.0.7.7.1](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip#MD5#feb7eab99c647a0b4347be9f0a3276de)

Given the fact JRE 17 packages aren't included into [corretto/corretto-17 releases](https://github.com/corretto/corretto-17/releases), we've decided to replace it with a complete JDK for NanoServer images.