### PR TITLE
[TEAMCITY-QA-T] Add a note on ARM support @ documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,27 @@ This image adds a TeamCity agent suitable for Java and .NET development.
 - [TeamCity Docker Images - tools](tool) - tools used within the release process of Docker Images.
 - [Automation Framework](tool/automation/framework) - framework for simplification of Docker Images release process.
 
+### A note on ARM support
+Currently, TeamCity Docker Images aren't provided for ARM-based architecture. Therefore, the following error would appear
+if a container is intended to be launched on that host platform:
+```
+docker pull jetbrains/teamcity-server
+...
+latest: Pulling from jetbrains/teamcity-server
+no matching manifest for linux/arm64/v8 in the manifest list entries
+```
+
+While we are actively working on expanding the list of supported platforms, currently, as an option for trying out TeamCity
+on ARM-based hosts, it is possible to explicitly execute image for AMD architectures via [`--platform` option of Docker](https://docs.docker.com/build/building/multi-platform/).
+```
+docker run --platform linux/amd64 jetbrains/teamcity-agent ...
+```
+Please, note that we recommend this option for testing and trying TeamCity locally, but not for production purposes.
+
+The following YouTrack issues could be used to track the progress on the development of ARM support for TeamCity Docker images:
+- [[TW-74465] Teamcity-agent ARM64/v8](https://youtrack.jetbrains.com/issue/TW-74465/Teamcity-agent-ARM64-v8)
+- [[TW-68887] Docker image. Support ARM architecture (AWS ECS Graviton ARM)](https://youtrack.jetbrains.com/issue/TW-68887/Docker-image.-Support-ARM-architecture-AWS-ECS-Graviton-ARM)
+
 ### Bugs/issues/problems
 
 Please use [these channels](https://www.jetbrains.com/help/teamcity/feedback.html) to give feedback on these images, thanks!

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This image adds a TeamCity agent suitable for Java and .NET development.
 
 ### ARM Support
 
-We do not currently provide native TeamCity Docker Images for ARM-based devices. If you attempt to launch a container on ARM, the following error is shown:
+We do not currently provide native TeamCity Docker images for ARM-based devices. If you attempt to launch a container on ARM, the following error is shown:
 
 ```
 docker pull jetbrains/teamcity-server
@@ -73,7 +73,7 @@ docker run --platform linux/amd64 jetbrains/teamcity-agent ...
 ```
 Note that we recommend this approach for testing purposes only.
 
-If you wish to track the progress of development native ARM images, follow these YouTrack issues:
+If you wish to track the progress of native ARM images development, follow these YouTrack issues:
 - [[TW-74465] Teamcity-agent ARM64/v8](https://youtrack.jetbrains.com/issue/TW-74465/Teamcity-agent-ARM64-v8)
 - [[TW-68887] Docker image. Support ARM architecture (AWS ECS Graviton ARM)](https://youtrack.jetbrains.com/issue/TW-68887/Docker-image.-Support-ARM-architecture-AWS-ECS-Graviton-ARM)
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ This image adds a TeamCity agent suitable for Java and .NET development.
 - [TeamCity Docker Images - tools](tool) - tools used within the release process of Docker Images.
 - [Automation Framework](tool/automation/framework) - framework for simplification of Docker Images release process.
 
-### A note on ARM support
-Currently, TeamCity Docker Images aren't provided for ARM-based architecture. Therefore, the following error would appear
-if a container is intended to be launched on that host platform:
+### ARM Support
+
+We do not currently provide native TeamCity Docker Images for ARM-based devices. If you attempt to launch a container on ARM, the following error is shown:
+
 ```
 docker pull jetbrains/teamcity-server
 ...
@@ -66,14 +67,13 @@ latest: Pulling from jetbrains/teamcity-server
 no matching manifest for linux/arm64/v8 in the manifest list entries
 ```
 
-While we are actively working on expanding the list of supported platforms, currently, as an option for trying out TeamCity
-on ARM-based hosts, it is possible to explicitly execute image for AMD architectures via [`--platform` option of Docker](https://docs.docker.com/build/building/multi-platform/).
+As a workaround, you can execute images for AMD architectures via the Docker [`--platform` option](https://docs.docker.com/build/building/multi-platform/) on your ARM host.
 ```
 docker run --platform linux/amd64 jetbrains/teamcity-agent ...
 ```
-Please, note that we recommend this option for testing and trying TeamCity locally, but not for production purposes.
+Note that we recommend this approach for testing purposes only.
 
-The following YouTrack issues could be used to track the progress on the development of ARM support for TeamCity Docker images:
+If you wish to track the progress of development native ARM images, follow these YouTrack issues:
 - [[TW-74465] Teamcity-agent ARM64/v8](https://youtrack.jetbrains.com/issue/TW-74465/Teamcity-agent-ARM64-v8)
 - [[TW-68887] Docker image. Support ARM architecture (AWS ECS Graviton ARM)](https://youtrack.jetbrains.com/issue/TW-68887/Docker-image.-Support-ARM-architecture-AWS-ECS-Graviton-ARM)
 


### PR DESCRIPTION
Currently, TeamCity Docker Images aren't provided for hosts with ARM-based architecture.

Until the development of Docker images for ARM-based architecture is complete (see: YouTrack tickets below), that would be useful to add a note about current state of the support, links that could be used to track the progress, and an option to try AMD-based TeamCity Docker image on an ARM-based host. 

- [[TW-74465] Teamcity-agent ARM64/v8](https://youtrack.jetbrains.com/issue/TW-74465/Teamcity-agent-ARM64-v8)
- [[TW-68887] Docker image. Support ARM architecture (AWS ECS Graviton ARM)](https://youtrack.jetbrains.com/issue/TW-68887/Docker-image.-Support-ARM-architecture-AWS-ECS-Graviton-ARM)

