### PR TITLE
[TEAMCITY-QA-T-289] Prevent build of AMD images on ARM agents

### DIFF
--- a/.teamcity/generated/HubProject.kts
+++ b/.teamcity/generated/HubProject.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object HubProject : Project({
 	 name = "Docker hub"

--- a/.teamcity/generated/LocalProject.kts
+++ b/.teamcity/generated/LocalProject.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object LocalProject : Project({
 	 name = "Staging registry"

--- a/.teamcity/generated/PublishHubVersion.kts
+++ b/.teamcity/generated/PublishHubVersion.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object publish_hub_version: BuildType({
 	 name = "Publish as version"
@@ -137,6 +138,8 @@ object publish_hub_version: BuildType({
 	requirements {
 		 noLessThanVer("docker.version", "18.05.0")
 		 contains("docker.server.osType", "windows")
+		// In order to correctly build AMD-based images, we wouldn't want it to be scheduled on ARM-based agent
+		doesNotContain("teamcity.agent.name", "arm")
 		 contains("teamcity.agent.jvm.os.name", "Windows 10")
 	}
 	 features {

--- a/.teamcity/generated/PublishLocal.kts
+++ b/.teamcity/generated/PublishLocal.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object publish_local: BuildType({
 	 name = "Publish"
@@ -142,6 +143,8 @@ object publish_local: BuildType({
 	requirements {
 		 noLessThanVer("docker.version", "18.05.0")
 		 contains("docker.server.osType", "windows")
+		// In order to correctly build AMD-based images, we wouldn't want it to be scheduled on ARM-based agent
+		doesNotContain("teamcity.agent.name", "arm")
 		 contains("teamcity.agent.jvm.os.name", "Windows 10")
 	}
 	 features {

--- a/.teamcity/generated/PushHubLinux.kts
+++ b/.teamcity/generated/PushHubLinux.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object push_hub_linux: BuildType({
 	 name = "Push linux"
@@ -164,6 +165,8 @@ object push_hub_linux: BuildType({
 	}
 	 requirements {
 	 	 contains("docker.server.osType", "linux")
+	 	// In order to correctly build AMD-based images, we wouldn't want it to be scheduled on ARM-based agent
+	 	doesNotContain("teamcity.agent.name", "arm")
 	 }
 		 dependencies {
 			 snapshot(PublishLocal.publish_local) {

--- a/.teamcity/generated/PushHubWindows.kts
+++ b/.teamcity/generated/PushHubWindows.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object push_hub_windows: BuildType({
 	 name = "Push windows"
@@ -280,6 +281,8 @@ object push_hub_windows: BuildType({
 	}
 	 requirements {
 	 	 contains("docker.server.osType", "windows")
+	 	// In order to correctly build AMD-based images, we wouldn't want it to be scheduled on ARM-based agent
+	 	doesNotContain("teamcity.agent.name", "arm")
 	 	 contains("teamcity.agent.jvm.os.name", "Windows 10")
 	 }
 		 dependencies {

--- a/.teamcity/generated/PushLocalLinux1804.kts
+++ b/.teamcity/generated/PushLocalLinux1804.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object push_local_linux_18_04 : BuildType({
 	 name = "ON PAUSE Build and push linux 18.04"

--- a/.teamcity/generated/PushLocalLinux2004.kts
+++ b/.teamcity/generated/PushLocalLinux2004.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object push_local_linux_20_04 : BuildType({
 	 name = "Build and push linux 20.04"
@@ -331,7 +332,7 @@ object push_local_linux_20_04 : BuildType({
 		dockerSupport {
 			 cleanupPushedImages = true
 			 loginToRegistry = on {
-				 dockerRegistryId = "PROJECT_EXT_774,PROJECT_EXT_315"
+				 dockerRegistryId = "PROJECT_EXT_774"
 			 }
 		}
 		swabra {
@@ -353,6 +354,8 @@ object push_local_linux_20_04 : BuildType({
 		 param("system.teamcity.agent.ensure.free.space", "8gb")
 	}
 	requirements {
+		// In order to correctly build AMD-based images, we wouldn't want it to be scheduled on ARM-based agent
+		doesNotContain("teamcity.agent.name", "arm")
 	}
 })
 

--- a/.teamcity/generated/PushLocalWindows1803.kts
+++ b/.teamcity/generated/PushLocalWindows1803.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object push_local_windows_1803 : BuildType({
 	 name = "ON PAUSE Build and push windows 1803"

--- a/.teamcity/generated/PushLocalWindows1809.kts
+++ b/.teamcity/generated/PushLocalWindows1809.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object push_local_windows_1809 : BuildType({
 	 name = "Build and push windows 1809"
@@ -255,7 +256,7 @@ object push_local_windows_1809 : BuildType({
 		dockerSupport {
 			 cleanupPushedImages = true
 			 loginToRegistry = on {
-				 dockerRegistryId = "PROJECT_EXT_774,PROJECT_EXT_315"
+				 dockerRegistryId = "PROJECT_EXT_774"
 			 }
 		}
 		swabra {
@@ -277,6 +278,8 @@ object push_local_windows_1809 : BuildType({
 		 param("system.teamcity.agent.ensure.free.space", "43gb")
 	}
 	requirements {
+		// In order to correctly build AMD-based images, we wouldn't want it to be scheduled on ARM-based agent
+		doesNotContain("teamcity.agent.name", "arm")
 		 contains("teamcity.agent.jvm.os.name", "Windows 10")
 	}
 })

--- a/.teamcity/generated/PushLocalWindows1903.kts
+++ b/.teamcity/generated/PushLocalWindows1903.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object push_local_windows_1903 : BuildType({
 	 name = "ON PAUSE Build and push windows 1903"

--- a/.teamcity/generated/PushLocalWindows1909.kts
+++ b/.teamcity/generated/PushLocalWindows1909.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object push_local_windows_1909 : BuildType({
 	 name = "ON PAUSE Build and push windows 1909"

--- a/.teamcity/generated/PushLocalWindows2004.kts
+++ b/.teamcity/generated/PushLocalWindows2004.kts
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import hosted.BuildAndPushHosted
 
 object push_local_windows_2004 : BuildType({
 	 name = "Build and push windows 2004"
@@ -255,7 +256,7 @@ object push_local_windows_2004 : BuildType({
 		dockerSupport {
 			 cleanupPushedImages = true
 			 loginToRegistry = on {
-				 dockerRegistryId = "PROJECT_EXT_774,PROJECT_EXT_315"
+				 dockerRegistryId = "PROJECT_EXT_774"
 			 }
 		}
 		swabra {
@@ -277,6 +278,8 @@ object push_local_windows_2004 : BuildType({
 		 param("system.teamcity.agent.ensure.free.space", "43gb")
 	}
 	requirements {
+		// In order to correctly build AMD-based images, we wouldn't want it to be scheduled on ARM-based agent
+		doesNotContain("teamcity.agent.name", "arm")
 		 contains("teamcity.agent.jvm.os.name", "Windows 10")
 	}
 })

--- a/tool/TeamCity.Docker/TeamCityKotlinSettingsGenerator.cs
+++ b/tool/TeamCity.Docker/TeamCityKotlinSettingsGenerator.cs
@@ -373,7 +373,7 @@ namespace TeamCity.Docker
             yield return "\t name = \"Validation of Size Regression - Staging Docker Images (Windows / Linux)\"";
             yield return $"\t {_buildNumberPattern}";
 
-            // VCS Root Is needed in order to launch automaiton framework
+            // VCS Root Is needed in order to launch automation framework
             yield return String.Join('\n',
                 "\t vcs {",
                 "\t\t root(TeamCityDockerImagesRepo)",
@@ -568,6 +568,11 @@ namespace TeamCity.Docker
             if (!string.IsNullOrWhiteSpace(platform))
             {
                 yield return $"\t contains(\"docker.server.osType\", \"{platform}\")";
+            }
+
+            if (!IsArmBasedImageBuildEnabled) {
+                yield return "\t// In order to correctly build AMD-based images, we wouldn't want it to be scheduled on ARM-based agent";
+                yield return $"\tdoesNotContain(\"teamcity.agent.name\", \"arm\")";
             }
 
             foreach (var requirement in requirements)


### PR DESCRIPTION
We would like to prevent situations when an AMD-based Docker Image would be attempted to be built on an ARM-based TeamCity Agent.