### PR TITLE
[TEAMCITY-QA-T] Fix Docker Image size trend retrieval with empty credentials.

### DIFF
--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/hub/DockerRegistryAccessor.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/hub/DockerRegistryAccessor.kt
@@ -35,7 +35,7 @@ class DockerRegistryAccessor(private val uri: String, credentials: DockerhubCred
             // -- parse JSON fields that don't have an assigned serializer into a String, e.g.: Number
             isLenient = true
         }
-        this.token = if (credentials != null) this.getPersonalAccessToken(credentials) else ""
+        this.token = if (credentials != null && credentials.isUsable()) this.getPersonalAccessToken(credentials) else ""
     }
 
     /**

--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/hub/auth/DockerhubCredentials.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/hub/auth/DockerhubCredentials.kt
@@ -16,4 +16,11 @@ class DockerhubCredentials {
         this.username = username?.trim() ?: ""
         this.token = token?.trim() ?: ""
     }
+
+    /**
+     * @return true if credentials are usable for DockerHub auth (both are non-empty)
+     */
+    fun isUsable(): Boolean {
+        return !(this.username.isNullOrEmpty() || this.token.isNullOrEmpty())
+    }
 }


### PR DESCRIPTION
Pull request is dedicated to prevention of NPE during an attempt to retrieve image size trend without explicit DockerHub credentials, e.g. for public repositories.