### PR TITLE
[TW-82170] Windows-based Docker agent images are not compatible with containerd

### DIFF
--- a/configs/windows/Agent/nanoserver/NanoServer1803.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer1803.Dockerfile
@@ -46,7 +46,7 @@ EXPOSE 9090
 
 VOLUME C:/BuildAgent/conf
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
 ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
@@ -67,7 +67,7 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
+RUN ["setx", "/M", "PATH", "\"%PATH%;%JAVA_HOME%\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet\""]
 USER ContainerUser
 
 ENV LOCALAPPDATA="C:\Users\ContainerUser\AppData\Local" \

--- a/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
@@ -90,4 +90,4 @@ USER ContainerUser
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
@@ -87,7 +87,7 @@ EXPOSE 9090
 
 VOLUME C:/BuildAgent/conf
 
-CMD ./BuildAgent/run-agent.ps1
+CMD ["./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
 ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
@@ -107,5 +107,5 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
     NUGET_XMLDOC_MODE=skip
 
 USER ContainerAdministrator
-RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
+RUN ["setx", "/M", "PATH", "(''{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial'' -f $env:PATH, $env:JAVA_HOME)"]
 USER ContainerUser

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1803.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1803.Dockerfile
@@ -65,4 +65,4 @@ RUN pwsh -NoLogo -NoProfile -Command " \
         Start-Sleep -Seconds 6 ; \
     }"
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
@@ -82,4 +82,4 @@ VOLUME C:/BuildAgent/work
 VOLUME C:/BuildAgent/temp
 VOLUME C:/BuildAgent/logs
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/configs/windows/Server/nanoserver/NanoServer1803.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer1803.Dockerfile
@@ -71,7 +71,7 @@ VOLUME $TEAMCITY_DATA_PATH \
        $CATALINA_TMPDIR
 
 
-CMD pwsh C:/TeamCity/run-server.ps1
+CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
@@ -102,7 +102,7 @@ VOLUME $TEAMCITY_DATA_PATH \
        $TEAMCITY_LOGS \
        $CATALINA_TMPDIR
 
-CMD pwsh C:/TeamCity/run-server.ps1
+CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/context/generated/windows/Agent/nanoserver/1803/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1803/Dockerfile
@@ -39,7 +39,7 @@ EXPOSE 9090
 
 VOLUME C:/BuildAgent/conf
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
 ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
@@ -60,7 +60,7 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
+RUN ["setx", "/M", "PATH", "\"%PATH%;%JAVA_HOME%\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet\""]
 USER ContainerUser
 
 ENV LOCALAPPDATA="C:\Users\ContainerUser\AppData\Local" \

--- a/context/generated/windows/Agent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1809/Dockerfile
@@ -80,4 +80,4 @@ USER ContainerUser
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/context/generated/windows/Agent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1903/Dockerfile
@@ -80,4 +80,4 @@ USER ContainerUser
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/context/generated/windows/Agent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1909/Dockerfile
@@ -80,4 +80,4 @@ USER ContainerUser
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/context/generated/windows/Agent/nanoserver/2004/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/2004/Dockerfile
@@ -80,4 +80,4 @@ USER ContainerUser
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
@@ -84,7 +84,7 @@ EXPOSE 9090
 
 VOLUME C:/BuildAgent/conf
 
-CMD ./BuildAgent/run-agent.ps1
+CMD ["./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
 ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
@@ -104,5 +104,5 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
     NUGET_XMLDOC_MODE=skip
 
 USER ContainerAdministrator
-RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
+RUN ["setx", "/M", "PATH", "(''{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial'' -f $env:PATH, $env:JAVA_HOME)"]
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
@@ -84,7 +84,7 @@ EXPOSE 9090
 
 VOLUME C:/BuildAgent/conf
 
-CMD ./BuildAgent/run-agent.ps1
+CMD ["./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
 ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
@@ -104,5 +104,5 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
     NUGET_XMLDOC_MODE=skip
 
 USER ContainerAdministrator
-RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
+RUN ["setx", "/M", "PATH", "(''{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial'' -f $env:PATH, $env:JAVA_HOME)"]
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
@@ -84,7 +84,7 @@ EXPOSE 9090
 
 VOLUME C:/BuildAgent/conf
 
-CMD ./BuildAgent/run-agent.ps1
+CMD ["./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
 ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
@@ -104,5 +104,5 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
     NUGET_XMLDOC_MODE=skip
 
 USER ContainerAdministrator
-RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
+RUN ["setx", "/M", "PATH", "(''{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial'' -f $env:PATH, $env:JAVA_HOME)"]
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
@@ -84,7 +84,7 @@ EXPOSE 9090
 
 VOLUME C:/BuildAgent/conf
 
-CMD ./BuildAgent/run-agent.ps1
+CMD ["./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
 ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
@@ -104,5 +104,5 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
     NUGET_XMLDOC_MODE=skip
 
 USER ContainerAdministrator
-RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
+RUN ["setx", "/M", "PATH", "(''{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial'' -f $env:PATH, $env:JAVA_HOME)"]
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/2004/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2004/Dockerfile
@@ -84,7 +84,7 @@ EXPOSE 9090
 
 VOLUME C:/BuildAgent/conf
 
-CMD ./BuildAgent/run-agent.ps1
+CMD ["./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
 ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
@@ -104,5 +104,5 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
     NUGET_XMLDOC_MODE=skip
 
 USER ContainerAdministrator
-RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
+RUN ["setx", "/M", "PATH", "(''{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial'' -f $env:PATH, $env:JAVA_HOME)"]
 USER ContainerUser

--- a/context/generated/windows/MinimalAgent/nanoserver/1803/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1803/Dockerfile
@@ -58,4 +58,4 @@ RUN pwsh -NoLogo -NoProfile -Command " \
         Start-Sleep -Seconds 6 ; \
     }"
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
@@ -75,4 +75,4 @@ VOLUME C:/BuildAgent/work
 VOLUME C:/BuildAgent/temp
 VOLUME C:/BuildAgent/logs
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
@@ -75,4 +75,4 @@ VOLUME C:/BuildAgent/work
 VOLUME C:/BuildAgent/temp
 VOLUME C:/BuildAgent/logs
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
@@ -75,4 +75,4 @@ VOLUME C:/BuildAgent/work
 VOLUME C:/BuildAgent/temp
 VOLUME C:/BuildAgent/logs
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile
@@ -75,4 +75,4 @@ VOLUME C:/BuildAgent/work
 VOLUME C:/BuildAgent/temp
 VOLUME C:/BuildAgent/logs
 
-CMD pwsh ./BuildAgent/run-agent.ps1
+CMD ["pwsh", "./BuildAgent/run-agent.ps1"]

--- a/context/generated/windows/Server/nanoserver/1803/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1803/Dockerfile
@@ -65,7 +65,7 @@ VOLUME $TEAMCITY_DATA_PATH \
        $CATALINA_TMPDIR
 
 
-CMD pwsh C:/TeamCity/run-server.ps1
+CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/context/generated/windows/Server/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1809/Dockerfile
@@ -98,7 +98,7 @@ VOLUME $TEAMCITY_DATA_PATH \
        $TEAMCITY_LOGS \
        $CATALINA_TMPDIR
 
-CMD pwsh C:/TeamCity/run-server.ps1
+CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/context/generated/windows/Server/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1903/Dockerfile
@@ -98,7 +98,7 @@ VOLUME $TEAMCITY_DATA_PATH \
        $TEAMCITY_LOGS \
        $CATALINA_TMPDIR
 
-CMD pwsh C:/TeamCity/run-server.ps1
+CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/context/generated/windows/Server/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1909/Dockerfile
@@ -98,7 +98,7 @@ VOLUME $TEAMCITY_DATA_PATH \
        $TEAMCITY_LOGS \
        $CATALINA_TMPDIR
 
-CMD pwsh C:/TeamCity/run-server.ps1
+CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/context/generated/windows/Server/nanoserver/2004/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/2004/Dockerfile
@@ -98,7 +98,7 @@ VOLUME $TEAMCITY_DATA_PATH \
        $TEAMCITY_LOGS \
        $CATALINA_TMPDIR
 
-CMD pwsh C:/TeamCity/run-server.ps1
+CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/tool/TeamCity.Docker/DockerGraphFactory.cs
+++ b/tool/TeamCity.Docker/DockerGraphFactory.cs
@@ -36,6 +36,10 @@ namespace TeamCity.Docker
             _pathService = pathService ?? throw new ArgumentNullException(nameof(pathService));
         }
 
+        /// <summary>
+        /// Generates Dockerfile out of given template.
+        /// </summary>
+        /// <param name="templates">parsed template files (e.g. from "configs/linux/*.Dockerfile")</param>
         public Result<IGraph<IArtifact, Dependency>> Create(IEnumerable<Template> templates)
         {
             var graph = new Graph<IArtifact, Dependency>();


### PR DESCRIPTION
AWS EKS uses containerd as the default container runtime engine starting from K8s 1.24 or higher. See `https://aws.amazon.com/blogs/containers/all-you-need-to-know-about-moving-to-containerd-on-amazon-eks/.`

There is a bug in containerd that causes windows-based Docker images with unescaped backward slashes in Dockerfile to fail when starting them in K8s. See this bug report: `https://github.com/containerd/containerd/issues/5067`.

As a workaround, one can change the container runtime engine from containerd to dockerd, but dockerd is only available in AWS EKS for K8s clusters with version 1.23 or lower.

The publicly available TeamCity agent images should be fully compatible with the default EKS settings without forcing the users to search for the workarounds.