### PR TITLE
[TEAMCITY-QA-T] Fix redundant Linux OS type requirements

### DIFF
--- a/.teamcity/delivery/staging/PushLocalLinux2004.kts
+++ b/.teamcity/delivery/staging/PushLocalLinux2004.kts
@@ -40,6 +40,7 @@ object push_local_linux_20_04 : BuildType({
     }
 
     requirements {
+        contains("docker.server.osType", "linux")
         // In order to correctly build AMD-based images, we wouldn't want it to be scheduled on ARM-based agent
         doesNotContain("teamcity.agent.name", "arm")
     }

--- a/.teamcity/utils/dsl/steps/DockerSteps.kt
+++ b/.teamcity/utils/dsl/steps/DockerSteps.kt
@@ -33,7 +33,6 @@ fun BuildSteps.buildImage(imageInfo: ImageInfo) {
             commandArgs = "--no-cache"
             namesAndTags = imageInfo.baseFqdn.trimIndent()
         }
-        param("dockerImage.platform", "linux")
     }
 
     this.dockerCommand {


### PR DESCRIPTION
Build configurations responsible for the build of Windows-based images have agents requirement implying it must have a Linux-based OS, while it's not needed.