### PR TITLE
[TEAMCITY-QA-T] Adjust trigger for scheduled (nightly) build of Docker 

### DIFF
--- a/.teamcity/scheduled/build/TeamCityDockerImagesScheduledBuild.kts
+++ b/.teamcity/scheduled/build/TeamCityDockerImagesScheduledBuild.kts
@@ -29,7 +29,7 @@ object TeamCityDockerImagesScheduledBuild : BuildType({
         schedule {
             id = "TRIGGER_TC_DOCKER_IMAGES_NIGHTLY"
             schedulingPolicy = daily {
-                hour = 0
+                hour = 2
                 minute = 15
             }
             branchFilter = "+:<default>"


### PR DESCRIPTION
The trigger alligns scheduled build configuration with potential planned (nightly) maintanence of TeamCity server.