### PR TITLE
[TEAMCITY-QA-T] Add publishing of manifest for aarch64-based images

### DIFF
--- a/.teamcity/generated/LocalProject.kts
+++ b/.teamcity/generated/LocalProject.kts
@@ -4,25 +4,7 @@
 package generated
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.ui.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import common.TeamCityDockerImagesRepo.TeamCityDockerImagesRepo
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.freeDiskSpace
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.kotlinFile
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
-import jetbrains.buildServer.configs.kotlin.v2019_2.Trigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.VcsTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
-import hosted.BuildAndPushHosted
+import hosted.arm.PushStagingLinux2004_Aarch64
 
 object LocalProject : Project({
 	 name = "Staging registry"

--- a/.teamcity/generated/PublishHubLatest.kts
+++ b/.teamcity/generated/PublishHubLatest.kts
@@ -39,7 +39,7 @@ object publish_hub_latest: BuildType({
 		 name = "manifest create teamcity-server:latest"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.deployRepository%teamcity-server:latest %docker.deployRepository%teamcity-server:2023.05.1-linux %docker.deployRepository%teamcity-server:2023.05.1-nanoserver-1809 %docker.deployRepository%teamcity-server:2023.05.1-nanoserver-2004"
+			 commandArgs = "create %docker.deployRepository%teamcity-server:latest %docker.deployRepository%teamcity-server:2023.05.1-linux %docker.deployRepository%teamcity-server:2023.05.1-linux-arm64 %docker.deployRepository%teamcity-server:2023.05.1-linux-arm64 %docker.deployRepository%teamcity-server:2023.05.1-nanoserver-1809 %docker.deployRepository%teamcity-server:2023.05.1-nanoserver-2004"
 		 }
 	}
 	dockerCommand {
@@ -60,7 +60,7 @@ object publish_hub_latest: BuildType({
 		 name = "manifest create teamcity-agent:latest"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.deployRepository%teamcity-agent:latest %docker.deployRepository%teamcity-agent:2023.05.1-linux %docker.deployRepository%teamcity-agent:2023.05.1-nanoserver-1809 %docker.deployRepository%teamcity-agent:2023.05.1-nanoserver-2004"
+			 commandArgs = "create %docker.deployRepository%teamcity-agent:latest %docker.deployRepository%teamcity-agent:2023.05.1-linux %docker.deployRepository%teamcity-agent:2023.05.1-linux-arm64 %docker.deployRepository%teamcity-agent:2023.05.1-nanoserver-1809 %docker.deployRepository%teamcity-agent:2023.05.1-nanoserver-2004"
 		 }
 	}
 	dockerCommand {
@@ -81,7 +81,7 @@ object publish_hub_latest: BuildType({
 		 name = "manifest create teamcity-minimal-agent:latest"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.deployRepository%teamcity-minimal-agent:latest %docker.deployRepository%teamcity-minimal-agent:2023.05.1-linux %docker.deployRepository%teamcity-minimal-agent:2023.05.1-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:2023.05.1-nanoserver-2004"
+			 commandArgs = "create %docker.deployRepository%teamcity-minimal-agent:latest %docker.deployRepository%teamcity-minimal-agent:2023.05.1-linux %docker.deployRepository%teamcity-minimal-agent:2023.05.1-linux-arm64 %docker.deployRepository%teamcity-minimal-agent:2023.05.1-nanoserver-1809 %docker.deployRepository%teamcity-minimal-agent:2023.05.1-nanoserver-2004"
 		 }
 	}
 	dockerCommand {

--- a/.teamcity/generated/PublishLocal.kts
+++ b/.teamcity/generated/PublishLocal.kts
@@ -39,7 +39,7 @@ object publish_local: BuildType({
 		 name = "manifest create teamcity-server:2023.05.1"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
+			 commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-linux-arm64 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
 		 }
 	}
 	dockerCommand {
@@ -60,7 +60,7 @@ object publish_local: BuildType({
 		 name = "manifest create teamcity-agent:2023.05.1"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
+			 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
 		 }
 	}
 	dockerCommand {
@@ -81,7 +81,7 @@ object publish_local: BuildType({
 		 name = "manifest create teamcity-minimal-agent:2023.05.1"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
+			 commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-linux-arm64 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
 		 }
 	}
 	dockerCommand {
@@ -123,7 +123,7 @@ object publish_local: BuildType({
 		 name = "manifest create teamcity-server:latest"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:latest %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
+			 commandArgs = "create %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:latest %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-linux-arm64 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-server%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
 		 }
 	}
 	dockerCommand {
@@ -144,7 +144,7 @@ object publish_local: BuildType({
 		 name = "manifest create teamcity-agent:latest"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:latest %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
+			 commandArgs = "create %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:latest %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-linux  %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-linux-arm64 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
 		 }
 	}
 	dockerCommand {
@@ -165,7 +165,7 @@ object publish_local: BuildType({
 		 name = "manifest create teamcity-minimal-agent:latest"
 		 commandType = other {
 			 subCommand = "manifest"
-			 commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:latest %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
+			 commandArgs = "create %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:latest %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-linux %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-linux-arm64 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-1809 %docker.buildRepository%teamcity-minimal-agent%docker.buildImagePostfix%:2023.05.1-nanoserver-2004"
 		 }
 	}
 	dockerCommand {

--- a/.teamcity/hosted/arm/PushStagingLinux2004_Aarch64.kts
+++ b/.teamcity/hosted/arm/PushStagingLinux2004_Aarch64.kts
@@ -1,4 +1,4 @@
-package generated
+package hosted.arm
 
 import common.TeamCityDockerImagesRepo
 import hosted.utils.ImageInfoRepository


### PR DESCRIPTION
Pull request is dedicated to include aarch64-based images into staging and production manifest for existing images, including Server, Minimal and Regular Agent.