### PR TITLE
[TEAMCITY-QA-T] Enhance automation for the verification of Docker Image's size

### DIFF
--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/common/constants/ValidationConstants.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/common/constants/ValidationConstants.kt
@@ -6,4 +6,5 @@ package com.jetbrains.teamcity.common.constants
 object ValidationConstants {
     const val ALLOWED_IMAGE_SIZE_INCREASE_THRESHOLD_PERCENT = 5.0f
     const val PRE_PRODUCTION_IMAGE_PREFIX = "EAP"
+    const val LATEST = "latest"
 }

--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/hub/DockerRegistryAccessor.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/hub/DockerRegistryAccessor.kt
@@ -155,9 +155,10 @@ class DockerRegistryAccessor(private val uri: String, credentials: DockerhubCred
         val lhsTagComponents = lhsImageTag.split(".").map { it.toIntOrNull() }
         val rhsTagComponents = rhsImageTag.split(".").map { it.toIntOrNull() }
 
-        for (i in 0 until minOf(lhsTagComponents.size, rhsTagComponents.size)) {
-            val lhsTagComponent = lhsTagComponents[i] ?: Int.MAX_VALUE
-            val rhsTagComponent = rhsTagComponents[i] ?: Int.MAX_VALUE
+        for (i in 0 until maxOf(lhsTagComponents.size, rhsTagComponents.size)) {
+            // e.g. 2023.05 transforms into 2023.05.0 for comparison purposes
+            val lhsTagComponent = lhsTagComponents[i] ?: 0
+            val rhsTagComponent = rhsTagComponents[i] ?: 0
             if (lhsTagComponent != rhsTagComponent) {
                 return lhsTagComponent.compareTo(rhsTagComponent)
             }

--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/validation/DockerImageValidationUtilities.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/validation/DockerImageValidationUtilities.kt
@@ -70,7 +70,8 @@ class DockerImageValidationUtilities {
                 // -- we will always have only 1 corresponding image, due to extensive criteria
                 val previousImage = dockerHubInfoOfPreviousRelease.images.first()
                 val percentageChange = MathUtils.getPercentageIncrease(associatedImage.size.toLong(), previousImage.size.toLong())
-                println("$originalImageFqdn-${associatedImage.os}-${associatedImage.osVersion}-${associatedImage.architecture}: "
+                val osVersion = "-${associatedImage.osVersion}" ?: ""
+                println("$originalImageFqdn-${associatedImage.os}${osVersion}-${associatedImage.architecture}: "
                         + "\n\t - Original size: ${associatedImage.size} ($originalImageFqdn)"
                         + "\n\t - Previous size: ${previousImage.size} (${dockerHubInfoOfPreviousRelease.name})"
                         + "\n\t - Percentage change: ${MathUtils.roundOffDecimal(percentageChange)}% (max allowable - $threshold%)\n")


### PR DESCRIPTION
Pull request is dedicated to the change within algorithm for verification of Docker Image's size, including the enhanced lookup. Previous lookup had used the date of publishing as the most important criteria. Now, we equally treat both publishing criteria and the tag itself, e.g. `2023.05.2`, `2022.10`.

Therefore, in case any previous release will receive a new bugfix (e.g. `2022.10.5`), the logic for validation of image size for the recent releases (e.g. `2023.05.2`) will still work properly.