### PR TITLE
[TW-83304] Agent Docker image's apt package manager doesn't trust the key of the apt Perforce repository

### DIFF
--- a/dockerhub/teamcity-agent/README.md
+++ b/dockerhub/teamcity-agent/README.md
@@ -158,6 +158,28 @@ docker commit my-customized-agent <the registry where you what to store the imag
 The image is available under the [TeamCity license](https://www.jetbrains.com/teamcity/buy/license.html).
 TeamCity is free for perpetual use with the limitation of 100 build configurations (jobs) and 3 agents. [Licensing details](https://www.jetbrains.com/help/teamcity/licensing-policy.html).
 
+## Troubleshooting
+
+### Apt manager distrusts the apt Perforce repository key.
+This issue applies exclusively to Docker images that were released **prior to August 14th, 2023**
+([TW-83304](https://youtrack.jetbrains.com/issue/TW-83304/Agent-Docker-images-apt-package-manager-doesnt-trust-the-key-of-the-apt-Perforce-repository)).
+
+Due to the expiration and subsequent renewal of the [Perforce Package key on August 14, 2023](https://www.perforce.com/perforce-packages),
+if modifications to `apt` packages in images based on containers released before that date would be made,
+the following error would be encountered:
+```
+$ apt-get update
+...
+Err:15 https://package.perforce.com/apt/ubuntu focal InRelease                                                                                                                                                                          
+  The following signatures were invalid: EXPKEYSIG 7123CB760FF18869 Perforce Software (Package Signing) <support+packaging@perforce.com>
+…
+```
+To prevent this error in images, we suggest executing this command in a container or including it in a Docker image
+build step before altering packages:
+```
+sudo apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey
+```
+
 ## Feedback
 
 Report issues of suggestions to the official TeamCity [issue tracker](https://youtrack.jetbrains.com/issues/TW).

--- a/dockerhub/teamcity-agent/README.md
+++ b/dockerhub/teamcity-agent/README.md
@@ -160,13 +160,12 @@ TeamCity is free for perpetual use with the limitation of 100 build configuratio
 
 ## Troubleshooting
 
-### Apt manager distrusts the apt Perforce repository key.
-This issue applies exclusively to Docker images that were released **prior to August 14th, 2023**
+### Apt manager distrusts the apt Perforce repository key
+
+This issue may occur for Docker images released **prior to August 14, 2023**
 ([TW-83304](https://youtrack.jetbrains.com/issue/TW-83304/Agent-Docker-images-apt-package-manager-doesnt-trust-the-key-of-the-apt-Perforce-repository)).
 
-Due to the expiration and subsequent renewal of the [Perforce Package key on August 14, 2023](https://www.perforce.com/perforce-packages),
-if modifications to `apt` packages in containers based on images released before that date would be made,
-the following error would be encountered:
+The [Perforce Package key](https://www.perforce.com/perforce-packages) expired and was updated on August 14, 2023. This results in the following error that occurs if you modify the `apt` packages in images based on containers released before this date:
 ```
 $ apt-get update
 ...
@@ -174,7 +173,7 @@ Err:15 https://package.perforce.com/apt/ubuntu focal InRelease
   The following signatures were invalid: EXPKEYSIG 7123CB760FF18869 Perforce Software (Package Signing) <support+packaging@perforce.com>
 …
 ```
-To prevent this error in images, we suggest executing this command in a container or including it in a Docker image
+To avoid this issue, execute this command in a container or include it in a Docker image
 build step before altering packages:
 ```
 sudo apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey

--- a/dockerhub/teamcity-agent/README.md
+++ b/dockerhub/teamcity-agent/README.md
@@ -165,7 +165,7 @@ This issue applies exclusively to Docker images that were released **prior to Au
 ([TW-83304](https://youtrack.jetbrains.com/issue/TW-83304/Agent-Docker-images-apt-package-manager-doesnt-trust-the-key-of-the-apt-Perforce-repository)).
 
 Due to the expiration and subsequent renewal of the [Perforce Package key on August 14, 2023](https://www.perforce.com/perforce-packages),
-if modifications to `apt` packages in images based on containers released before that date would be made,
+if modifications to `apt` packages in containers based on images released before that date would be made,
 the following error would be encountered:
 ```
 $ apt-get update

--- a/dockerhub/teamcity-minimal-agent/README.md
+++ b/dockerhub/teamcity-minimal-agent/README.md
@@ -86,13 +86,12 @@ TeamCity is free for perpetual use with the limitation of 100 build configuratio
 
 ## Troubleshooting
 
-### Apt manager distrusts the apt Perforce repository key.
-This issue applies exclusively to Docker images that were released **prior to August 14th, 2023**
+### Apt manager distrusts the apt Perforce repository key
+
+This issue may occur for Docker images released **prior to August 14, 2023**
 ([TW-83304](https://youtrack.jetbrains.com/issue/TW-83304/Agent-Docker-images-apt-package-manager-doesnt-trust-the-key-of-the-apt-Perforce-repository)).
 
-Due to the expiration and subsequent renewal of the [Perforce Package key on August 14, 2023](https://www.perforce.com/perforce-packages),
-if modifications to `apt` packages containers based on images released before that date would be made,
-the following error would be encountered:
+The [Perforce Package key](https://www.perforce.com/perforce-packages) expired and was updated on August 14, 2023. This results in the following error that occurs if you modify the `apt` packages in images based on containers released before this date:
 ```
 $ apt-get update
 ...
@@ -100,11 +99,12 @@ Err:15 https://package.perforce.com/apt/ubuntu focal InRelease
   The following signatures were invalid: EXPKEYSIG 7123CB760FF18869 Perforce Software (Package Signing) <support+packaging@perforce.com>
 …
 ```
-To prevent this error in images, we suggest executing this command in a container or including it in a Docker image
+To avoid this issue, execute this command in a container or include it in a Docker image
 build step before altering packages:
 ```
 sudo apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey
 ```
+
 
 ## Feedback
 

--- a/dockerhub/teamcity-minimal-agent/README.md
+++ b/dockerhub/teamcity-minimal-agent/README.md
@@ -84,6 +84,28 @@ docker commit my-customized-agent <the registry where you what to store the imag
 The image is available under the [TeamCity license](https://www.jetbrains.com/teamcity/buy/license.html).
 TeamCity is free for perpetual use with the limitation of 100 build configurations (jobs) and 3 agents. [Licensing details](https://www.jetbrains.com/help/teamcity/licensing-policy.html).
 
+## Troubleshooting
+
+### Apt manager distrusts the apt Perforce repository key.
+This issue applies exclusively to Docker images that were released **prior to August 14th, 2023**
+([TW-83304](https://youtrack.jetbrains.com/issue/TW-83304/Agent-Docker-images-apt-package-manager-doesnt-trust-the-key-of-the-apt-Perforce-repository)).
+
+Due to the expiration and subsequent renewal of the [Perforce Package key on August 14, 2023](https://www.perforce.com/perforce-packages),
+if modifications to `apt` packages in images based on containers released before that date would be made,
+the following error would be encountered:
+```
+$ apt-get update
+...
+Err:15 https://package.perforce.com/apt/ubuntu focal InRelease                                                                                                                                                                          
+  The following signatures were invalid: EXPKEYSIG 7123CB760FF18869 Perforce Software (Package Signing) <support+packaging@perforce.com>
+…
+```
+To prevent this error in images, we suggest executing this command in a container or including it in a Docker image
+build step before altering packages:
+```
+sudo apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey
+```
+
 ## Feedback
 
 Report issues of suggestions to the official TeamCity [issue tracker](https://youtrack.jetbrains.com/issues/TW).

--- a/dockerhub/teamcity-minimal-agent/README.md
+++ b/dockerhub/teamcity-minimal-agent/README.md
@@ -91,7 +91,7 @@ This issue applies exclusively to Docker images that were released **prior to Au
 ([TW-83304](https://youtrack.jetbrains.com/issue/TW-83304/Agent-Docker-images-apt-package-manager-doesnt-trust-the-key-of-the-apt-Perforce-repository)).
 
 Due to the expiration and subsequent renewal of the [Perforce Package key on August 14, 2023](https://www.perforce.com/perforce-packages),
-if modifications to `apt` packages in images based on containers released before that date would be made,
+if modifications to `apt` packages containers based on images released before that date would be made,
 the following error would be encountered:
 ```
 $ apt-get update

--- a/dockerhub/teamcity-server/README.md
+++ b/dockerhub/teamcity-server/README.md
@@ -166,13 +166,12 @@ TeamCity is free for perpetual use with the limitation of 100 build configuratio
 
 ## Troubleshooting
 
-### Apt manager distrusts the apt Perforce repository key.
-This issue applies exclusively to Docker images that were released **prior to August 14th, 2023**
+### Apt manager distrusts the apt Perforce repository key
+
+This issue may occur for Docker images released **prior to August 14, 2023**
 ([TW-83304](https://youtrack.jetbrains.com/issue/TW-83304/Agent-Docker-images-apt-package-manager-doesnt-trust-the-key-of-the-apt-Perforce-repository)).
 
-Due to the expiration and subsequent renewal of the [Perforce Package key on August 14, 2023](https://www.perforce.com/perforce-packages),
-if modifications to `apt` packages in containers based on images released before that date would be made, 
-the following error would be encountered:
+The [Perforce Package key](https://www.perforce.com/perforce-packages) expired and was updated on August 14, 2023. This results in the following error that occurs if you modify the `apt` packages in images based on containers released before this date:
 ```
 $ apt-get update
 ...
@@ -180,11 +179,12 @@ Err:15 https://package.perforce.com/apt/ubuntu focal InRelease
   The following signatures were invalid: EXPKEYSIG 7123CB760FF18869 Perforce Software (Package Signing) <support+packaging@perforce.com>
 …
 ```
-To prevent this error in images, we suggest executing this command in a container or including it in a Docker image 
+To avoid this issue, execute this command in a container or include it in a Docker image
 build step before altering packages:
 ```
 sudo apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey
 ```
+
 
 ## Feedback
 

--- a/dockerhub/teamcity-server/README.md
+++ b/dockerhub/teamcity-server/README.md
@@ -171,7 +171,7 @@ This issue applies exclusively to Docker images that were released **prior to Au
 ([TW-83304](https://youtrack.jetbrains.com/issue/TW-83304/Agent-Docker-images-apt-package-manager-doesnt-trust-the-key-of-the-apt-Perforce-repository)).
 
 Due to the expiration and subsequent renewal of the [Perforce Package key on August 14, 2023](https://www.perforce.com/perforce-packages),
-if modifications to `apt` packages in images based on containers released before that date would be made, 
+if modifications to `apt` packages in containers based on images released before that date would be made, 
 the following error would be encountered:
 ```
 $ apt-get update

--- a/dockerhub/teamcity-server/README.md
+++ b/dockerhub/teamcity-server/README.md
@@ -176,7 +176,7 @@ the following error would be encountered:
 ```
 $ apt-get update
 ...
-Err:15 http://package.perforce.com/apt/ubuntu focal InRelease                                                                                                                                                                          
+Err:15 https://package.perforce.com/apt/ubuntu focal InRelease                                                                                                                                                                          
   The following signatures were invalid: EXPKEYSIG 7123CB760FF18869 Perforce Software (Package Signing) <support+packaging@perforce.com>
 …
 ```

--- a/dockerhub/teamcity-server/README.md
+++ b/dockerhub/teamcity-server/README.md
@@ -164,6 +164,28 @@ If you changed the image, you will need to replicate the changes to the new Team
 The image is available under the [TeamCity license](https://www.jetbrains.com/teamcity/buy/license.html).
 TeamCity is free for perpetual use with the limitation of 100 build configurations (jobs) and 3 agents. [Licensing details](https://www.jetbrains.com/help/teamcity/licensing-policy.html).
 
+## Troubleshooting
+
+### Apt manager distrusts the apt Perforce repository key.
+This issue applies exclusively to Docker images that were released **prior to August 14th, 2023**
+([TW-83304](https://youtrack.jetbrains.com/issue/TW-83304/Agent-Docker-images-apt-package-manager-doesnt-trust-the-key-of-the-apt-Perforce-repository)).
+
+Due to the expiration and subsequent renewal of the [Perforce Package key on August 14, 2023](https://www.perforce.com/perforce-packages),
+if modifications to `apt` packages in images based on containers released before that date would be made, 
+the following error would be encountered:
+```
+$ apt-get update
+...
+Err:15 http://package.perforce.com/apt/ubuntu focal InRelease                                                                                                                                                                          
+  The following signatures were invalid: EXPKEYSIG 7123CB760FF18869 Perforce Software (Package Signing) <support+packaging@perforce.com>
+…
+```
+To prevent this error in images, we suggest executing this command in a container or including it in a Docker image 
+build step before altering packages:
+```
+sudo apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey
+```
+
 ## Feedback
 
 Report issues of suggestions to the official TeamCity [issue tracker](https://youtrack.jetbrains.com/issues/TW).


### PR DESCRIPTION
Running `apt-get update` inside the agent container to produce this error:

```
W: GPG error: http://package.perforce.com/apt/ubuntu focal InRelease: The following signatures were invalid: EXPKEYSIG 7123CB760FF18869 Perforce Software (Package Signing) <support+packaging@perforce.com>
E: The repository 'http://package.perforce.com/apt/ubuntu focal InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```