### PR TITLE
[TEAMCITY-QA-T] Add ability to ignore `-staging` postfix @ Size Validation

### DIFF
--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/Automation.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/Automation.kt
@@ -28,13 +28,12 @@ class ValidateImage : Subcommand("validate", "Validate Docker Image with (option
         val image = validationArgs[0]
         val username = if (validationArgs.size > 1) validationArgs[1] else null
         val token = if (validationArgs.size > 2) validationArgs[2] else null
-        val ignoreStaging = if (validationArgs.size > 3) validationArgs[3] else false
-
         val imagesFailedValidation = DockerImageValidationUtilities.validateImageSize(
             originalImageFqdn = image,
             registryUri = "https://hub.docker.com/v2",
             threshold = ValidationConstants.ALLOWED_IMAGE_SIZE_INCREASE_THRESHOLD_PERCENT,
-            credentials = getDockerhubCredentials(username, token)
+            credentials = getDockerhubCredentials(username, token),
+            ignoreStaging = true
         )
 
         if (imagesFailedValidation.isNotEmpty()) {

--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/Automation.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/Automation.kt
@@ -25,29 +25,24 @@ class ValidateImage : Subcommand("validate", "Validate Docker Image with (option
      * Execute image validation option specified via CLI.
      */
     override fun execute() {
-
-        // 1. Capture current image size
-        val originalImageName = validationArgs[0]
-
+        val image = validationArgs[0]
         val username = if (validationArgs.size > 1) validationArgs[1] else null
         val token = if (validationArgs.size > 2) validationArgs[2] else null
-        val credentials: DockerhubCredentials = getDockerhubCredentials(username, token)
+        val ignoreStaging = if (validationArgs.size > 3) validationArgs[3] else false
 
-
-        val percentageChangeThreshold = ValidationConstants.ALLOWED_IMAGE_SIZE_INCREASE_THRESHOLD_PERCENT
         val imagesFailedValidation = DockerImageValidationUtilities.validateImageSize(
-            originalImageName,
-            "https://hub.docker.com/v2",
-            percentageChangeThreshold,
-            credentials
+            originalImageFqdn = image,
+            registryUri = "https://hub.docker.com/v2",
+            threshold = ValidationConstants.ALLOWED_IMAGE_SIZE_INCREASE_THRESHOLD_PERCENT,
+            credentials = getDockerhubCredentials(username, token)
         )
 
         if (imagesFailedValidation.isNotEmpty()) {
             imagesFailedValidation.forEach {
-                println("Validation failed for ${originalImageName}, OS: ${it.os}, OS version: ${it.osVersion}, architecture: ${it.architecture}")
+                println("Validation failed for ${image}, OS: ${it.os}, OS version: ${it.osVersion}, architecture: ${it.architecture}")
             }
             // throw exception in order to handle it within upstream DSL
-            throw DockerImageValidationException("Validation had failed for $originalImageName")
+            throw DockerImageValidationException("Validation had failed for $image")
         }
     }
 }

--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/common/constants/ValidationConstants.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/common/constants/ValidationConstants.kt
@@ -7,4 +7,5 @@ object ValidationConstants {
     const val ALLOWED_IMAGE_SIZE_INCREASE_THRESHOLD_PERCENT = 5.0f
     const val PRE_PRODUCTION_IMAGE_PREFIX = "EAP"
     const val LATEST = "latest"
+    const val STAGING_POSTFIX = "-staging"
 }

--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/common/network/HttpRequestsUtilities.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/common/network/HttpRequestsUtilities.kt
@@ -1,7 +1,5 @@
 package com.jetbrains.teamcity.common.network
 
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import java.io.IOException
 import java.net.ConnectException
 import java.net.URI

--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/hub/DockerRegistryAccessor.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/hub/DockerRegistryAccessor.kt
@@ -59,9 +59,10 @@ class DockerRegistryAccessor(private val uri: String, credentials: DockerhubCred
      * @param pageSize maximal amount of images to be included into Dockerhub's response
      */
     fun getInfoAboutImagesInRegistry(image: DockerImage, pageSize: Int): DockerRegistryInfoAboutImages? {
+        val repo = image.repo.replace("-staging", "")
         val registryResponse: HttpResponse<String?> = httpRequestsUtilities.getJsonWithAuth(
             "${this.uri}/repositories"
-                    + "/${image.repo}/tags?page_size=$pageSize", this.token
+                    + "/${repo}/tags?page_size=$pageSize", this.token
         )
         val result = registryResponse.body() ?: ""
 
@@ -105,8 +106,7 @@ class DockerRegistryAccessor(private val uri: String, credentials: DockerhubCred
             .filter { return@filter isSameDistribution(currentImage.tag, it.name) }
             // Sort based on tag
             .sortedWith { lhs, rhs -> imageTagComparator(lhs.name, rhs.name) }
-            .last()
-
+            .lastOrNull() ?: throw RuntimeException("Previous images weren't found for $currentImage")
 
         // -- 1. Filter by OS type
         previousImageRepository.images = previousImageRepository.images.filter { it.os == targetOs }

--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/hub/DockerRegistryAccessor.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/hub/DockerRegistryAccessor.kt
@@ -22,15 +22,14 @@ class DockerRegistryAccessor(private val uri: String, credentials: DockerhubCred
 
     private val httpRequestsUtilities: HttpRequestsUtilities = HttpRequestsUtilities()
     private val token: String?
-    private val jsonSerializer: Json
+    private val jsonSerializer: Json = Json {
+        // -- remove the necessity to include parsing of unused fields
+        ignoreUnknownKeys = true
+        // -- parse JSON fields that don't have an assigned serializer into a String, e.g.: Number
+        isLenient = true
+    }
 
     init {
-        this.jsonSerializer = Json {
-            // -- remove the necessity to include parsing of unused fields
-            ignoreUnknownKeys = true
-            // -- parse JSON fields that don't have an assigned serializer into a String, e.g.: Number
-            isLenient = true
-        }
         this.token = if (credentials != null && credentials.isUsable()) this.getPersonalAccessToken(credentials) else ""
     }
 
@@ -59,7 +58,7 @@ class DockerRegistryAccessor(private val uri: String, credentials: DockerhubCred
      * @param pageSize maximal amount of images to be included into Dockerhub's response
      */
     fun getInfoAboutImagesInRegistry(image: DockerImage, pageSize: Int): DockerRegistryInfoAboutImages? {
-        val repo = image.repo.replace("-staging", "")
+        val repo = image.repo.replace(ValidationConstants.STAGING_POSTFIX, "")
         val registryResponse: HttpResponse<String?> = httpRequestsUtilities.getJsonWithAuth(
             "${this.uri}/repositories"
                     + "/${repo}/tags?page_size=$pageSize", this.token

--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/validation/DockerImageValidationUtilities.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/validation/DockerImageValidationUtilities.kt
@@ -44,6 +44,7 @@ class DockerImageValidationUtilities {
          * 4. Compare the size of each corresponding image.
          * @param originalImageFqdn fully-qualified domain name of the original image
          * @param registryUri URI of Docker Registry where image is placed
+         * @param ignoreStaging if true, staging images would be compared to production ones
          * @returns list of associated images that didn't pass the validation.
          */
         fun validateImageSize(

--- a/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/validation/DockerImageValidationUtilities.kt
+++ b/tool/automation/framework/app/src/main/kotlin/com/jetbrains/teamcity/docker/validation/DockerImageValidationUtilities.kt
@@ -50,9 +50,10 @@ class DockerImageValidationUtilities {
             originalImageFqdn: String,
             registryUri: String,
             threshold: Float,
-            credentials: DockerhubCredentials?
+            credentials: DockerhubCredentials?,
+            ignoreStaging: Boolean
         ): ArrayList<DockerhubImage> {
-            val registryAccessor = DockerRegistryAccessor(registryUri, credentials)
+            val registryAccessor = DockerRegistryAccessor(registryUri, ignoreStaging, credentials)
 
             val currentImage = DockerImage(originalImageFqdn)
             val imagesFailedValidation = ArrayList<DockerhubImage>()


### PR DESCRIPTION
That'd be useful to have the ability to ignore `-staging` postfix, in order to compare the images with the ones located at Dockerhub.