### PR TITLE
[TEAMCITY-QA-T] Sanity check of build number at pre-push stage: number correctness, no 'EAP' notation

### DIFF
--- a/.teamcity/delivery/arm/PushProductionLinux2004_Aarch64.kts
+++ b/.teamcity/delivery/arm/PushProductionLinux2004_Aarch64.kts
@@ -20,6 +20,10 @@ object push_production_linux_2004_aarch64 : BuildType({
 
     steps {
         ImageInfoRepository.getArmLinuxImages2004().forEach { imageInfo ->
+            verifyBuildNumInLinuxImage(image = imageInfo)
+        }
+
+        ImageInfoRepository.getArmLinuxImages2004().forEach { imageInfo ->
             moveToProduction(imageInfo)
         }
     }

--- a/.teamcity/delivery/production/PushHubLinux.kts
+++ b/.teamcity/delivery/production/PushHubLinux.kts
@@ -5,6 +5,7 @@ import utils.dsl.general.publishStagingManifests
 import utils.dsl.general.teamCityImageBuildFeatures
 import utils.dsl.steps.moveToProduction
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import utils.dsl.steps.verifyBuildNumInLinuxImage
 
 object push_hub_linux : BuildType({
     name = "[Linux] [Production] Release TeamCity Docker Images into Production Registry"
@@ -16,6 +17,10 @@ object push_hub_linux : BuildType({
     }
 
     steps {
+        ImageInfoRepository.getAmdLinuxImages2004().forEach { imageInfo ->
+            verifyBuildNumInLinuxImage(image = imageInfo)
+        }
+
         ImageInfoRepository.getAmdLinuxImages2004().forEach { imageInfo ->
             moveToProduction(imageInfo)
         }

--- a/.teamcity/delivery/production/PushHubWindows.kts
+++ b/.teamcity/delivery/production/PushHubWindows.kts
@@ -5,6 +5,7 @@ import utils.dsl.general.publishStagingManifests
 import utils.dsl.general.teamCityImageBuildFeatures
 import utils.dsl.steps.moveToProduction
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import utils.dsl.steps.verifyBuildNumInWindowsImage
 
 object push_hub_windows : BuildType({
     name = "[Windows] [Production] Release TeamCity Docker Images into Production Registry"
@@ -16,6 +17,16 @@ object push_hub_windows : BuildType({
     }
 
     steps {
+        // Check build within Windows 1809-based Docker Images
+        ImageInfoRepository.getWindowsImages1809().forEach { imageInfo ->
+            verifyBuildNumInWindowsImage(image = imageInfo, tcBuildNum = "%dockerImage.teamcity.buildNumber%")
+        }
+
+        // Check build within Windows 2004-based Docker Images
+        ImageInfoRepository.getWindowsImages2004().forEach { imageInfo ->
+            verifyBuildNumInWindowsImage(image = imageInfo, tcBuildNum = "%dockerImage.teamcity.buildNumber%")
+        }
+
         // Move Windows 1809-based Docker Images into production registry
         ImageInfoRepository.getWindowsImages1809().forEach { imageInfo ->
             moveToProduction(imageInfo)


### PR DESCRIPTION
Test automation covers sanity check of build number at staging phase. It might lead to the situation when an unexpected change would be made, and a build number in resulting production image will be different. 

Pull request adds a sanity check to prevent such situation.