### PR TITLE
[TEAMCITY-QA-T] Include the publication of Windows-based images from the scheduled build into the nightly repository.

### DIFF
--- a/.teamcity/scheduled/build/TeamCityScheduledImageBuildWindows.kts
+++ b/.teamcity/scheduled/build/TeamCityScheduledImageBuildWindows.kts
@@ -18,9 +18,6 @@ object TeamCityScheduledImageBuildWindows : BuildType({
         root(TeamCityDockerImagesRepo_AllBranches)
     }
 
-    // all .yml files (e.g. compose samples)
-    artifactRules = "+:*.yml"
-
     params {
         // the images will be published into registry that holds nightly builds
         param("docker.buildRepository", "%docker.nightlyRepository%")


### PR DESCRIPTION
The pull request is dedicated to adding a process for publishing Windows-based Docker images created within a scheduled build to a nightly repository.