### PR TITLE
[TW-76937] Add manifest for sudo images, including 'latest' ones

### DIFF
--- a/.teamcity/delivery/ImageValidation.kts
+++ b/.teamcity/delivery/ImageValidation.kts
@@ -38,7 +38,8 @@ object image_validation : BuildType({
     val targetImages: HashMap<String, String> = hashMapOf(
         "teamcity-server-%tc.image.version%-linux" to "%docker.deployRepository%teamcity-server%docker.buildImagePostfix%:%tc.image.version%-linux",
         "teamcity-agent-%tc.image.version%-linux" to "%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:%tc.image.version%-linux",
-        "teamcity-agent-%tc.image.version%-linux-sudo" to "%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:%tc.image.version%-linux-sudo",
+        "teamcity-agent-%tc.image.version%-linux-arm64-sudo" to "%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:%tc.image.version%-linux-arm64-sudo",
+        "teamcity-agent-%tc.image.version%-linux-amd64-sudo" to "%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:%tc.image.version%-linux-amd64-sudo",
         "teamcity-minimal-agent-%tc.image.version%-linux" to "%docker.deployRepository%teamcity-minimal-agent%docker.buildImagePostfix%:%tc.image.version%-linux",
         "teamcity-server-%tc.image.version%-nanoserver-1809" to "%docker.deployRepository%teamcity-server%docker.buildImagePostfix%:%tc.image.version%-nanoserver-1809",
         "teamcity-agent-%tc.image.version%-windowsservercore-1809" to "%docker.deployRepository%teamcity-agent%docker.buildImagePostfix%:%tc.image.version%-windowsservercore-1809",

--- a/.teamcity/scheduled/build/base/TeamCityScheduledImageBuildLinux_Base.kt
+++ b/.teamcity/scheduled/build/base/TeamCityScheduledImageBuildLinux_Base.kt
@@ -1,19 +1,16 @@
-import common.TeamCityDockerImagesRepo
 import common.TeamCityDockerImagesRepo_AllBranches
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import utils.ImageInfoRepository
 import utils.Utils
-import utils.models.ImageInfo
-import utils.dsl.steps.buildImage
-import utils.dsl.steps.publishToStaging
-import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import utils.config.DeliveryConfig
 import utils.config.Registries
 import utils.dsl.general.teamCityBuildDistDocker
 import utils.dsl.general.teamCityImageBuildFeatures
-import java.lang.IllegalArgumentException
+import utils.dsl.steps.buildImage
+import utils.dsl.steps.publishLinuxManifests
+import utils.dsl.steps.publishToStaging
+import utils.models.ImageInfo
 
 /**
  * Base class for the build of Linux-based Docker images.
@@ -64,6 +61,9 @@ class TeamCityScheduledImageBuildLinux_Base(private val platform: String, privat
 
         // publish images if build of each one of them succeeded
         images.forEach { imageInfo -> publishToStaging(imageInfo) }
+
+        // publish manifests
+        publishLinuxManifests(name = "%dockerImage.teamcity.buildNumber%", repo = "%docker.nightlyRepository%")
 
         script {
             name = "Generate Sample docker-compose manifest for the created images"

--- a/.teamcity/scheduled/build/base/TeamCityScheduledImageBuildLinux_Base.kt
+++ b/.teamcity/scheduled/build/base/TeamCityScheduledImageBuildLinux_Base.kt
@@ -63,7 +63,7 @@ class TeamCityScheduledImageBuildLinux_Base(private val platform: String, privat
         images.forEach { imageInfo -> publishToStaging(imageInfo) }
 
         // publish manifests
-        publishLinuxManifests(name = "%dockerImage.teamcity.buildNumber%", repo = "%docker.nightlyRepository%")
+        // publishLinuxManifests(name = "%dockerImage.teamcity.buildNumber%", repo = "%docker.nightlyRepository%")
 
         script {
             name = "Generate Sample docker-compose manifest for the created images"

--- a/.teamcity/utils/ImageInfoRepository.kt
+++ b/.teamcity/utils/ImageInfoRepository.kt
@@ -53,6 +53,16 @@ class ImageInfoRepository {
         }
 
         /**
+         * Returns the tags of all expected TeamCity Sudo-capable Agent instances.
+         */
+        fun getAllSudoAgentTags(version: String): List<String> {
+            return listOf(
+                "$version-linux-arm64-sudo",
+                "$version-linux-amd64-sudo"
+            )
+        }
+
+        /**
          * Returns a set of Ubuntu 20.04 (amd64)-based TeamCity Docker Images
          */
         fun getAmdLinuxImages2004(
@@ -81,11 +91,11 @@ class ImageInfoRepository {
                     "${prodRepo}teamcity-agent:${version}-linux"
                 ),
                 ImageInfo(
-                    "teamcity-agent:${version}-linux-sudo",
+                    "teamcity-agent:${version}-linux-amd64-sudo",
                     "context/generated/linux/Agent/Ubuntu/20.04-sudo/Dockerfile",
-                    "teamcity-agent:${dockerfileTag}-linux-sudo",
-                    "${stagingRepo}teamcity-agent${namePostfix}:${version}-linux-sudo",
-                    "${prodRepo}teamcity-agent:${version}-linux-sudo"
+                    "teamcity-agent:${dockerfileTag}-linux-amd64-sudo",
+                    "${stagingRepo}teamcity-agent${namePostfix}:${version}-linux-amd64-sudo",
+                    "${prodRepo}teamcity-agent:${version}-linux-amd64-sudo"
                 ),
 
                 // Servers

--- a/.teamcity/utils/dsl/steps/DockerSteps.kt
+++ b/.teamcity/utils/dsl/steps/DockerSteps.kt
@@ -161,12 +161,12 @@ fun BuildSteps.publishLinuxManifests(name: String, repo: String, postfix: String
         name
     )
 
-    // 4. Linux SUDO images
+    // 4. Publish Agent-sudo Manifests
     val sudoAgentTags = ImageInfoRepository.getAllSudoAgentTags(ver)
     publishManifest(
         imageName = "${repo}teamcity-agent${postfix}",
         tags = sudoAgentTags,
-        manifestTag = "${name}-sudo"
+        manifestTag = "${name}-linux-sudo"
     )
 }
 

--- a/.teamcity/utils/dsl/steps/DockerSteps.kt
+++ b/.teamcity/utils/dsl/steps/DockerSteps.kt
@@ -160,6 +160,14 @@ fun BuildSteps.publishLinuxManifests(name: String, repo: String, postfix: String
         minAgentTags,
         name
     )
+
+    // 4. Linux SUDO images
+    val sudoAgentTags = ImageInfoRepository.getAllSudoAgentTags(ver)
+    publishManifest(
+        imageName = "${repo}teamcity-agent${postfix}",
+        tags = sudoAgentTags,
+        manifestTag = "${name}-sudo"
+    )
 }
 
 /**

--- a/.teamcity/utils/dsl/steps/DockerSteps.kt
+++ b/.teamcity/utils/dsl/steps/DockerSteps.kt
@@ -146,26 +146,30 @@ fun BuildSteps.publishLinuxManifests(name: String, repo: String, postfix: String
     val ver = version.ifEmpty { name }
 
     // 1. Publish Server Manifests
-    val serverTags = ImageInfoRepository.getAllServerTags(ver)
-    publishManifest("${repo}teamcity-server${postfix}", serverTags, name)
+    publishManifest(
+        imageName = "${repo}teamcity-server${postfix}",
+        tags = ImageInfoRepository.getAllServerTags(ver),
+        manifestTag = name
+    )
 
     // 2. Publish Agent Manifests
-    val agentTags = ImageInfoRepository.getAllAgentTags(ver)
-    publishManifest("${repo}teamcity-agent${postfix}", agentTags, name)
+    publishManifest(
+        imageName = "${repo}teamcity-agent${postfix}",
+        tags = ImageInfoRepository.getAllAgentTags(ver),
+        manifestTag = name
+    )
 
     // 3. Publish Minimal Agent Manifests
-    val minAgentTags = ImageInfoRepository.getAllMinimalAgentTags(ver)
     publishManifest(
-        "${repo}teamcity-minimal-agent${postfix}",
-        minAgentTags,
-        name
+        imageName = "${repo}teamcity-minimal-agent${postfix}",
+        tags = ImageInfoRepository.getAllMinimalAgentTags(ver),
+        manifestTag = name
     )
 
     // 4. Publish Agent-sudo Manifests
-    val sudoAgentTags = ImageInfoRepository.getAllSudoAgentTags(ver)
     publishManifest(
         imageName = "${repo}teamcity-agent${postfix}",
-        tags = sudoAgentTags,
+        tags = ImageInfoRepository.getAllSudoAgentTags(ver),
         manifestTag = "${name}-linux-sudo"
     )
 }


### PR DESCRIPTION
Currently, we have 2 types of Linux-sudo TeamCity Agent images: `amd64` and `arm64`.
That'd be useful to have:
1. A manifest that'd link both of the images and provide the one matching host system of the user;
2. Have a `latest` version of such manifest;

Therefore, the following image structure will be implemented:
```
jetbrains/teamcity-agent:2023.05.4-linux-sudo
| - jetbrains/teamcity-agent:2023.05.4-linux-arm64-sudo
| - jetbrains/teamcity-agent:2023.05.4-linux-amd64-sudo

jetbrains/teamcity-agent:latest-linux-sudo
| - jetbrains/teamcity-agent:latest-linux-arm64-sudo
| - jetbrains/teamcity-agent:latest-linux-amd64-sudo
```