### PR TITLE
[TW-84615] Include producing of TeamCity's DevKit into CI/CD (w/o TeamCity inside)

### DIFF
--- a/configs/devkit/linux/agent/Ubuntu.devkit.Dockerfile
+++ b/configs/devkit/linux/agent/Ubuntu.devkit.Dockerfile
@@ -1,0 +1,15 @@
+#
+# The DevKit container is the environment in which TeamCity is executed. It is as an environment for the testing ...
+# ... of potential tooling extension and security testing purposes.
+#
+
+ARG teamCityAgentImage
+
+FROM ${teamCityAgentImage}
+
+USER root
+
+RUN rm -rf /opt/buildagent
+USER buildagent
+
+CMD ["sleep", "infinity"]

--- a/configs/devkit/linux/server/ubuntu/Ubuntu.devkit.Dockerfile
+++ b/configs/devkit/linux/server/ubuntu/Ubuntu.devkit.Dockerfile
@@ -1,0 +1,15 @@
+#
+# The DevKit container is the environment in which TeamCity is executed. It is as an environment for the testing ...
+# ... of potential tooling extension and security testing purposes.
+#
+
+ARG teamCityServerImage
+
+FROM ${teamCityServerImage}
+
+USER root
+
+RUN rm -rf /opt/teamcity
+USER tcuser:tcuser
+
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
In context of enhancing quality gates for TeamCity Security Testing, we would like to check potential CVE problems in context of tooling we provide within our Docker Images.

In order to classify security issues preciesly, we would like to check the tooling separtely, without potential TeamCity problems.

