### PR TITLE
[TW] Address issue with volume deletion on AMD host @ DevKit

### DIFF
--- a/configs/devkit/linux/agent/Ubuntu.devkit.Dockerfile
+++ b/configs/devkit/linux/agent/Ubuntu.devkit.Dockerfile
@@ -11,16 +11,16 @@ FROM ${teamCityImage}
 USER root
 
 # Remove agent code sequentially to work around the inability to delete volumes from the base image.
-RUN rm -rf '/opt/buildagent/bin' && \
-    rm -rf '/opt/buildagent/tools' && \
-    rm -rf '/opt/buildagent/system' && \
-    rm -rf '/opt/buildagent/plugins' && \
-    rm -rf '/opt/buildagent/temp' && \
-    rm -rf '/opt/buildagent/work' && \
-    rm -rf '/opt/buildagent/lib' && \
-    rm -rf '/opt/buildagent/conf' && \
-    rm -rf '/opt/buildagent/launcher' && \
-    rm -rf '/data/teamcity_agent/conf'
+RUN rm -rf '/opt/buildagent/bin/*' && \
+    rm -rf '/opt/buildagent/tools/*' && \
+    rm -rf '/opt/buildagent/system/*' && \
+    rm -rf '/opt/buildagent/plugins/*' && \
+    rm -rf '/opt/buildagent/temp/*' && \
+    rm -rf '/opt/buildagent/work/*' && \
+    rm -rf '/opt/buildagent/lib/*' && \
+    rm -rf '/opt/buildagent/conf/*' && \
+    rm -rf '/opt/buildagent/launcher/*' && \
+    rm -rf '/data/teamcity_agent/conf/*'
 
 USER buildagent
 


### PR DESCRIPTION
Running Docker on an AMD host, unlike ARM, it's not possible to delete the previously declared volume - that would result into "Device or Resource is Busy", as the directory would be held by Docker mount.

As a workaround, in order to achieve DevKit's need - an image wit tooling, but without TeamCity inside - it's possible to delete folder's contents instead of a complete mounted directory.