### PR TITLE
[Documentation @ 2023.11.x] Remove Windows 2004 from supported platforms, update 'latest' tag

### DIFF
--- a/configs/version.config
+++ b/configs/version.config
@@ -1,10 +1,10 @@
 # EAP params:
-versionTag=2023.11
-latestTag=
+#versionTag=2023.11
+#latestTag=latest
 
 # Release params:
-# versionTag=2023.11
-# latestTag=latest
+versionTag=2023.11
+latestTag=latest
 
 # For images based on ready-made TeamCity images
 refVersionTag=${versionTag}

--- a/configs/windows/Agent/nanoserver/2004/NanoServer1809.Dockerfile.config
+++ b/configs/windows/Agent/nanoserver/2004/NanoServer1809.Dockerfile.config
@@ -1,6 +1,6 @@
 windowsBuild=2004
 tag=nanoserver-${windowsBuild}
-repo=https://hub.docker.com/r/jetbrains/
+repo=
 # https://hub.docker.com/_/microsoft-powershell
 powershellImage=mcr.microsoft.com/powershell:nanoserver-${windowsBuild}
 # https://hub.docker.com/_/microsoft-windows-nanoserver

--- a/configs/windows/Agent/windowsservercore/2004/WindowsServerCore1803.Dockerfile.config
+++ b/configs/windows/Agent/windowsservercore/2004/WindowsServerCore1803.Dockerfile.config
@@ -1,6 +1,6 @@
 windowsBuild=2004
 tag=windowsservercore-${windowsBuild}
-repo=https://hub.docker.com/r/jetbrains/
+repo=
 # https://hub.docker.com/_/microsoft-dotnet-framework-sdk/
 windowsservercoreImage=mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-${windowsBuild}
 teamcityMinimalAgentImage=teamcity-minimal-agent:${versionTag}-nanoserver-${windowsBuild}

--- a/configs/windows/MinimalAgent/nanoserver/2004/NanoServer1809.Dockerfile.config
+++ b/configs/windows/MinimalAgent/nanoserver/2004/NanoServer1809.Dockerfile.config
@@ -1,6 +1,6 @@
 windowsBuild=2004
 tag=nanoserver-${windowsBuild}
-repo=https://hub.docker.com/r/jetbrains/
+repo=
 # https://hub.docker.com/_/microsoft-powershell
 powershellImage=mcr.microsoft.com/powershell:nanoserver-${windowsBuild}
 # https://hub.docker.com/_/microsoft-windows-nanoserver

--- a/configs/windows/Server/nanoserver/2004/NanoServer1809.Dockerfile.config
+++ b/configs/windows/Server/nanoserver/2004/NanoServer1809.Dockerfile.config
@@ -1,6 +1,6 @@
 windowsBuild=2004
 tag=nanoserver-${windowsBuild}
-repo=https://hub.docker.com/r/jetbrains/
+repo=
 # https://hub.docker.com/_/microsoft-powershell
 powershellImage=mcr.microsoft.com/powershell:nanoserver-${windowsBuild}
 # https://hub.docker.com/_/microsoft-windows-nanoserver

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -53,46 +53,42 @@ When running an image with multi-architecture support, docker will automatically
 
 ### latest
 
-Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
+Supported platforms: linux 20.04, windows 1809, windows 2022
 
 #### Content
 
 - [2023.11-linux](#202311-linux)
 - [2023.11-linux-arm64](#202311-linux-arm64)
 - [2023.11-nanoserver-1809](#202311-nanoserver-1809)
-- [2023.11-nanoserver-2004](#202311-nanoserver-2004)
 - [2023.11-nanoserver-2022](#202311-nanoserver-2022)
 
 ### 2023.11
 
-Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
+Supported platforms: linux 20.04, windows 1809, windows 2022
 
 #### Content
 
 - [2023.11-linux](#202311-linux)
 - [2023.11-linux-arm64](#202311-linux-arm64)
 - [2023.11-nanoserver-1809](#202311-nanoserver-1809)
-- [2023.11-nanoserver-2004](#202311-nanoserver-2004)
 - [2023.11-nanoserver-2022](#202311-nanoserver-2022)
 
 ### latest-windowsservercore
 
-Supported platforms: windows 1809, windows 2004, windows 2022
+Supported platforms: windows 1809, windows 2022
 
 #### Content
 
 - [2023.11-windowsservercore-1809](#202311-windowsservercore-1809)
-- [2023.11-windowsservercore-2004](#202311-windowsservercore-2004)
 - [2023.11-windowsservercore-2022](#202311-windowsservercore-2022)
 
 ### 2023.11-windowsservercore
 
-Supported platforms: windows 1809, windows 2004, windows 2022
+Supported platforms: windows 1809, windows 2022
 
 #### Content
 
 - [2023.11-windowsservercore-1809](#202311-windowsservercore-1809)
-- [2023.11-windowsservercore-2004](#202311-windowsservercore-2004)
 - [2023.11-windowsservercore-2022](#202311-windowsservercore-2022)
 
 
@@ -295,41 +291,6 @@ docker build -f "context/generated/windows/Agent/nanoserver/1809/Dockerfile" -t 
 
 _The required free space to generate image(s) is about **40 GB**._
 
-### 2023.11-nanoserver-2004
-
-[Dockerfile](windows/Agent/nanoserver/2004/Dockerfile)
-
-This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) build agent image.
-
-The docker image is available on:
-
-- [https://hub.docker.com/r/jetbrains/teamcity-agent](https://hub.docker.com/r/jetbrains/teamcity-agent)
-
-Installed components:
-
-- [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) feb7eab99c647a0b4347be9f0a3276de](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip)
-- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
-- [Git x64 v.2.43.0 Checksum (SHA256) 1905d93068e986258fafc69517df8fddff829bb2a289c1fa4dcc6cdf720ddf36](https://github.com/git-for-windows/git/releases/download/v2.43.0.windows.1/MinGit-2.43.0-64-bit.zip)
-- [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) a9e1bbb52484ad0667b258451ebb6b47ce6c7b788c015aee8a86c5e0c4dcf4ee8c82d796921869d64c92bb2afef2c7ceea09cfe255d8519d48f2471a098c361e](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-win-x64.zip)
-
-Container platform: windows
-
-Docker build commands:
-
-```
-docker pull mcr.microsoft.com/windows/nanoserver:2004
-docker pull mcr.microsoft.com/powershell:nanoserver-2004
-docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004
-echo TeamCity/webapps > context/.dockerignore
-echo TeamCity/devPackage >> context/.dockerignore
-echo TeamCity/lib >> context/.dockerignore
-docker build -f "context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile" -t teamcity-minimal-agent:2023.11-nanoserver-2004 "context"
-docker build -f "context/generated/windows/Agent/windowsservercore/2004/Dockerfile" -t teamcity-agent:2023.11-windowsservercore-2004 "context"
-docker build -f "context/generated/windows/Agent/nanoserver/2004/Dockerfile" -t teamcity-agent:2023.11-nanoserver-2004 "context"
-```
-
-_The required free space to generate image(s) is about **40 GB**._
-
 ### 2023.11-nanoserver-2022
 
 [Dockerfile](windows/Agent/nanoserver/2022/Dockerfile)
@@ -396,41 +357,6 @@ echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore
 docker build -f "context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile" -t teamcity-minimal-agent:2023.11-nanoserver-1809 "context"
 docker build -f "context/generated/windows/Agent/windowsservercore/1809/Dockerfile" -t teamcity-agent:2023.11-windowsservercore-1809 "context"
-```
-
-_The required free space to generate image(s) is about **38 GB**._
-
-### 2023.11-windowsservercore-2004
-
-[Dockerfile](windows/Agent/windowsservercore/2004/Dockerfile)
-
-This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) build agent image.
-
-The docker image is available on:
-
-- [https://hub.docker.com/r/jetbrains/teamcity-agent](https://hub.docker.com/r/jetbrains/teamcity-agent)
-
-Installed components:
-
-- [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) feb7eab99c647a0b4347be9f0a3276de](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip)
-- [Git x64 v.2.43.0 Checksum (SHA256) 1905d93068e986258fafc69517df8fddff829bb2a289c1fa4dcc6cdf720ddf36](https://github.com/git-for-windows/git/releases/download/v2.43.0.windows.1/MinGit-2.43.0-64-bit.zip)
-- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
-- [Mercurial x64 v.5.9.1](https://www.mercurial-scm.org/release/windows/mercurial-5.9.1-x64.msi)
-- [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) a9e1bbb52484ad0667b258451ebb6b47ce6c7b788c015aee8a86c5e0c4dcf4ee8c82d796921869d64c92bb2afef2c7ceea09cfe255d8519d48f2471a098c361e](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-win-x64.zip)
-
-Container platform: windows
-
-Docker build commands:
-
-```
-docker pull mcr.microsoft.com/windows/nanoserver:2004
-docker pull mcr.microsoft.com/powershell:nanoserver-2004
-docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004
-echo TeamCity/webapps > context/.dockerignore
-echo TeamCity/devPackage >> context/.dockerignore
-echo TeamCity/lib >> context/.dockerignore
-docker build -f "context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile" -t teamcity-minimal-agent:2023.11-nanoserver-2004 "context"
-docker build -f "context/generated/windows/Agent/windowsservercore/2004/Dockerfile" -t teamcity-agent:2023.11-windowsservercore-2004 "context"
 ```
 
 _The required free space to generate image(s) is about **38 GB**._
@@ -715,6 +641,38 @@ docker build -f "context/generated/windows/Agent/nanoserver/1909/Dockerfile" -t 
 
 _The required free space to generate image(s) is about **40 GB**._
 
+### 2023.11-nanoserver-2004
+
+[Dockerfile](windows/Agent/nanoserver/2004/Dockerfile)
+
+This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) build agent image.
+The docker image is not available and may be created manually.
+
+Installed components:
+
+- [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) feb7eab99c647a0b4347be9f0a3276de](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip)
+- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
+- [Git x64 v.2.43.0 Checksum (SHA256) 1905d93068e986258fafc69517df8fddff829bb2a289c1fa4dcc6cdf720ddf36](https://github.com/git-for-windows/git/releases/download/v2.43.0.windows.1/MinGit-2.43.0-64-bit.zip)
+- [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) a9e1bbb52484ad0667b258451ebb6b47ce6c7b788c015aee8a86c5e0c4dcf4ee8c82d796921869d64c92bb2afef2c7ceea09cfe255d8519d48f2471a098c361e](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-win-x64.zip)
+
+Container platform: windows
+
+Docker build commands:
+
+```
+docker pull mcr.microsoft.com/windows/nanoserver:2004
+docker pull mcr.microsoft.com/powershell:nanoserver-2004
+docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004
+echo TeamCity/webapps > context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+docker build -f "context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile" -t teamcity-minimal-agent:2023.11-nanoserver-2004 "context"
+docker build -f "context/generated/windows/Agent/windowsservercore/2004/Dockerfile" -t teamcity-agent:2023.11-windowsservercore-2004 "context"
+docker build -f "context/generated/windows/Agent/nanoserver/2004/Dockerfile" -t teamcity-agent:2023.11-nanoserver-2004 "context"
+```
+
+_The required free space to generate image(s) is about **40 GB**._
+
 ### 2023.11-windowsservercore-1803
 
 [Dockerfile](windows/Agent/windowsservercore/1803/Dockerfile)
@@ -806,6 +764,38 @@ echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore
 docker build -f "context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile" -t teamcity-minimal-agent:2023.11-nanoserver-1909 "context"
 docker build -f "context/generated/windows/Agent/windowsservercore/1909/Dockerfile" -t teamcity-agent:2023.11-windowsservercore-1909 "context"
+```
+
+_The required free space to generate image(s) is about **38 GB**._
+
+### 2023.11-windowsservercore-2004
+
+[Dockerfile](windows/Agent/windowsservercore/2004/Dockerfile)
+
+This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) build agent image.
+The docker image is not available and may be created manually.
+
+Installed components:
+
+- [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) feb7eab99c647a0b4347be9f0a3276de](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip)
+- [Git x64 v.2.43.0 Checksum (SHA256) 1905d93068e986258fafc69517df8fddff829bb2a289c1fa4dcc6cdf720ddf36](https://github.com/git-for-windows/git/releases/download/v2.43.0.windows.1/MinGit-2.43.0-64-bit.zip)
+- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
+- [Mercurial x64 v.5.9.1](https://www.mercurial-scm.org/release/windows/mercurial-5.9.1-x64.msi)
+- [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) a9e1bbb52484ad0667b258451ebb6b47ce6c7b788c015aee8a86c5e0c4dcf4ee8c82d796921869d64c92bb2afef2c7ceea09cfe255d8519d48f2471a098c361e](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-win-x64.zip)
+
+Container platform: windows
+
+Docker build commands:
+
+```
+docker pull mcr.microsoft.com/windows/nanoserver:2004
+docker pull mcr.microsoft.com/powershell:nanoserver-2004
+docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-2004
+echo TeamCity/webapps > context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+docker build -f "context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile" -t teamcity-minimal-agent:2023.11-nanoserver-2004 "context"
+docker build -f "context/generated/windows/Agent/windowsservercore/2004/Dockerfile" -t teamcity-agent:2023.11-windowsservercore-2004 "context"
 ```
 
 _The required free space to generate image(s) is about **38 GB**._

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -9,7 +9,9 @@ Other tags
 
 When running an image with multi-architecture support, docker will automatically select an image variant which matches your OS and architecture.
 
+- [latest](#latest)
 - [2023.11](#202311)
+- [latest-windowsservercore](#latest-windowsservercore)
 - [2023.11-windowsservercore](#202311-windowsservercore)
 
 #### linux
@@ -49,6 +51,18 @@ When running an image with multi-architecture support, docker will automatically
   - [2023.11-windowsservercore-1803](#202311-windowsservercore-1803)
 
 
+### latest
+
+Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
+
+#### Content
+
+- [2023.11-linux](#202311-linux)
+- [2023.11-linux-arm64](#202311-linux-arm64)
+- [2023.11-nanoserver-1809](#202311-nanoserver-1809)
+- [2023.11-nanoserver-2004](#202311-nanoserver-2004)
+- [2023.11-nanoserver-2022](#202311-nanoserver-2022)
+
 ### 2023.11
 
 Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
@@ -60,6 +74,16 @@ Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
 - [2023.11-nanoserver-1809](#202311-nanoserver-1809)
 - [2023.11-nanoserver-2004](#202311-nanoserver-2004)
 - [2023.11-nanoserver-2022](#202311-nanoserver-2022)
+
+### latest-windowsservercore
+
+Supported platforms: windows 1809, windows 2004, windows 2022
+
+#### Content
+
+- [2023.11-windowsservercore-1809](#202311-windowsservercore-1809)
+- [2023.11-windowsservercore-2004](#202311-windowsservercore-2004)
+- [2023.11-windowsservercore-2022](#202311-windowsservercore-2022)
 
 ### 2023.11-windowsservercore
 

--- a/context/generated/teamcity-minimal-agent.md
+++ b/context/generated/teamcity-minimal-agent.md
@@ -9,6 +9,7 @@ Other tags
 
 When running an image with multi-architecture support, docker will automatically select an image variant which matches your OS and architecture.
 
+- [latest](#latest)
 - [2023.11](#202311)
 
 #### linux
@@ -35,6 +36,17 @@ When running an image with multi-architecture support, docker will automatically
 - 1803
   - [2023.11-nanoserver-1803](#202311-nanoserver-1803)
 
+
+### latest
+
+Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
+
+#### Content
+
+- [2023.11-linux](#202311-linux)
+- [2023.11-nanoserver-1809](#202311-nanoserver-1809)
+- [2023.11-nanoserver-2004](#202311-nanoserver-2004)
+- [2023.11-nanoserver-2022](#202311-nanoserver-2022)
 
 ### 2023.11
 

--- a/context/generated/teamcity-minimal-agent.md
+++ b/context/generated/teamcity-minimal-agent.md
@@ -39,24 +39,22 @@ When running an image with multi-architecture support, docker will automatically
 
 ### latest
 
-Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
+Supported platforms: linux 20.04, windows 1809, windows 2022
 
 #### Content
 
 - [2023.11-linux](#202311-linux)
 - [2023.11-nanoserver-1809](#202311-nanoserver-1809)
-- [2023.11-nanoserver-2004](#202311-nanoserver-2004)
 - [2023.11-nanoserver-2022](#202311-nanoserver-2022)
 
 ### 2023.11
 
-Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
+Supported platforms: linux 20.04, windows 1809, windows 2022
 
 #### Content
 
 - [2023.11-linux](#202311-linux)
 - [2023.11-nanoserver-1809](#202311-nanoserver-1809)
-- [2023.11-nanoserver-2004](#202311-nanoserver-2004)
 - [2023.11-nanoserver-2022](#202311-nanoserver-2022)
 
 
@@ -115,36 +113,6 @@ echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore
 docker build -f "context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile" -t teamcity-minimal-agent:2023.11-nanoserver-1809 "context"
-```
-
-_The required free space to generate image(s) is about **10 GB**._
-
-### 2023.11-nanoserver-2004
-
-[Dockerfile](windows/MinimalAgent/nanoserver/2004/Dockerfile)
-
-This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) build agent image.
-
-The docker image is available on:
-
-- [https://hub.docker.com/r/jetbrains/teamcity-minimal-agent](https://hub.docker.com/r/jetbrains/teamcity-minimal-agent)
-
-Installed components:
-
-- [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) feb7eab99c647a0b4347be9f0a3276de](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip)
-- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
-
-Container platform: windows
-
-Docker build commands:
-
-```
-docker pull mcr.microsoft.com/windows/nanoserver:2004
-docker pull mcr.microsoft.com/powershell:nanoserver-2004
-echo TeamCity/webapps > context/.dockerignore
-echo TeamCity/devPackage >> context/.dockerignore
-echo TeamCity/lib >> context/.dockerignore
-docker build -f "context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile" -t teamcity-minimal-agent:2023.11-nanoserver-2004 "context"
 ```
 
 _The required free space to generate image(s) is about **10 GB**._
@@ -333,6 +301,33 @@ echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore
 docker build -f "context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile" -t teamcity-minimal-agent:2023.11-nanoserver-1909 "context"
+```
+
+_The required free space to generate image(s) is about **10 GB**._
+
+### 2023.11-nanoserver-2004
+
+[Dockerfile](windows/MinimalAgent/nanoserver/2004/Dockerfile)
+
+This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) build agent image.
+The docker image is not available and may be created manually.
+
+Installed components:
+
+- [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) feb7eab99c647a0b4347be9f0a3276de](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip)
+- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
+
+Container platform: windows
+
+Docker build commands:
+
+```
+docker pull mcr.microsoft.com/windows/nanoserver:2004
+docker pull mcr.microsoft.com/powershell:nanoserver-2004
+echo TeamCity/webapps > context/.dockerignore
+echo TeamCity/devPackage >> context/.dockerignore
+echo TeamCity/lib >> context/.dockerignore
+docker build -f "context/generated/windows/MinimalAgent/nanoserver/2004/Dockerfile" -t teamcity-minimal-agent:2023.11-nanoserver-2004 "context"
 ```
 
 _The required free space to generate image(s) is about **10 GB**._

--- a/context/generated/teamcity-server.md
+++ b/context/generated/teamcity-server.md
@@ -9,6 +9,7 @@ Other tags
 
 When running an image with multi-architecture support, docker will automatically select an image variant which matches your OS and architecture.
 
+- [latest](#latest)
 - [2023.11](#202311)
 
 #### linux
@@ -35,6 +36,17 @@ When running an image with multi-architecture support, docker will automatically
 - 1803
   - [2023.11-nanoserver-1803](#202311-nanoserver-1803)
 
+
+### latest
+
+Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
+
+#### Content
+
+- [2023.11-linux](#202311-linux)
+- [2023.11-nanoserver-1809](#202311-nanoserver-1809)
+- [2023.11-nanoserver-2004](#202311-nanoserver-2004)
+- [2023.11-nanoserver-2022](#202311-nanoserver-2022)
 
 ### 2023.11
 

--- a/context/generated/teamcity-server.md
+++ b/context/generated/teamcity-server.md
@@ -39,24 +39,22 @@ When running an image with multi-architecture support, docker will automatically
 
 ### latest
 
-Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
+Supported platforms: linux 20.04, windows 1809, windows 2022
 
 #### Content
 
 - [2023.11-linux](#202311-linux)
 - [2023.11-nanoserver-1809](#202311-nanoserver-1809)
-- [2023.11-nanoserver-2004](#202311-nanoserver-2004)
 - [2023.11-nanoserver-2022](#202311-nanoserver-2022)
 
 ### 2023.11
 
-Supported platforms: linux 20.04, windows 1809, windows 2004, windows 2022
+Supported platforms: linux 20.04, windows 1809, windows 2022
 
 #### Content
 
 - [2023.11-linux](#202311-linux)
 - [2023.11-nanoserver-1809](#202311-nanoserver-1809)
-- [2023.11-nanoserver-2004](#202311-nanoserver-2004)
 - [2023.11-nanoserver-2022](#202311-nanoserver-2022)
 
 
@@ -115,35 +113,6 @@ docker pull mcr.microsoft.com/powershell:nanoserver-1809
 echo TeamCity/buildAgent > context/.dockerignore
 echo TeamCity/temp >> context/.dockerignore
 docker build -f "context/generated/windows/Server/nanoserver/1809/Dockerfile" -t teamcity-server:2023.11-nanoserver-1809 "context"
-```
-
-_The required free space to generate image(s) is about **6 GB**._
-
-### 2023.11-nanoserver-2004
-
-[Dockerfile](windows/Server/nanoserver/2004/Dockerfile)
-
-This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) server image. The image is suitable for production use and evaluation purposes.
-
-The docker image is available on:
-
-- [https://hub.docker.com/r/jetbrains/teamcity-server](https://hub.docker.com/r/jetbrains/teamcity-server)
-
-Installed components:
-
-- [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) feb7eab99c647a0b4347be9f0a3276de](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip)
-- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
-- [Git x64 v.2.43.0 Checksum (SHA256) 1905d93068e986258fafc69517df8fddff829bb2a289c1fa4dcc6cdf720ddf36](https://github.com/git-for-windows/git/releases/download/v2.43.0.windows.1/MinGit-2.43.0-64-bit.zip)
-
-Container platform: windows
-
-Docker build commands:
-
-```
-docker pull mcr.microsoft.com/powershell:nanoserver-2004
-echo TeamCity/buildAgent > context/.dockerignore
-echo TeamCity/temp >> context/.dockerignore
-docker build -f "context/generated/windows/Server/nanoserver/2004/Dockerfile" -t teamcity-server:2023.11-nanoserver-2004 "context"
 ```
 
 _The required free space to generate image(s) is about **6 GB**._
@@ -330,6 +299,32 @@ docker pull mcr.microsoft.com/powershell:nanoserver-1909
 echo TeamCity/buildAgent > context/.dockerignore
 echo TeamCity/temp >> context/.dockerignore
 docker build -f "context/generated/windows/Server/nanoserver/1909/Dockerfile" -t teamcity-server:2023.11-nanoserver-1909 "context"
+```
+
+_The required free space to generate image(s) is about **6 GB**._
+
+### 2023.11-nanoserver-2004
+
+[Dockerfile](windows/Server/nanoserver/2004/Dockerfile)
+
+This is an official [JetBrains TeamCity](https://www.jetbrains.com/teamcity/) server image. The image is suitable for production use and evaluation purposes.
+The docker image is not available and may be created manually.
+
+Installed components:
+
+- [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) feb7eab99c647a0b4347be9f0a3276de](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip)
+- [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
+- [Git x64 v.2.43.0 Checksum (SHA256) 1905d93068e986258fafc69517df8fddff829bb2a289c1fa4dcc6cdf720ddf36](https://github.com/git-for-windows/git/releases/download/v2.43.0.windows.1/MinGit-2.43.0-64-bit.zip)
+
+Container platform: windows
+
+Docker build commands:
+
+```
+docker pull mcr.microsoft.com/powershell:nanoserver-2004
+echo TeamCity/buildAgent > context/.dockerignore
+echo TeamCity/temp >> context/.dockerignore
+docker build -f "context/generated/windows/Server/nanoserver/2004/Dockerfile" -t teamcity-server:2023.11-nanoserver-2004 "context"
 ```
 
 _The required free space to generate image(s) is about **6 GB**._


### PR DESCRIPTION
Pull request is deidcated to:
* The removal of Windows 2004-based images as "officially supported platform", given the deprecation of the OS and its corresponding replacement with Windows 2022.
* The update of `latest` tag for 2023.11 verison. 