### PR TITLE
[TCQA] Update permissions for regular Win2022 agents.

### DIFF
--- a/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
@@ -96,8 +96,8 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
+RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount::(OI)(CI)F'
+RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
 USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache

--- a/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
@@ -96,8 +96,8 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount::(OI)(CI)F'
-RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache

--- a/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
@@ -95,6 +95,9 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
@@ -106,6 +106,6 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount::(OI)(CI)F'
-RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 USER ContainerUser

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
@@ -105,4 +105,7 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 USER ContainerUser

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
@@ -106,6 +106,6 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
+RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount::(OI)(CI)F'
+RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
 USER ContainerUser

--- a/context/generated/windows/Agent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/2022/Dockerfile
@@ -86,8 +86,8 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount::(OI)(CI)F'
-RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache

--- a/context/generated/windows/Agent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/2022/Dockerfile
@@ -86,8 +86,8 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
+RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount::(OI)(CI)F'
+RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
 USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache

--- a/context/generated/windows/Agent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/2022/Dockerfile
@@ -85,6 +85,9 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -101,6 +101,6 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount::(OI)(CI)F'
-RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -6,7 +6,7 @@ ARG gitWindowsComponentSHA256='1905d93068e986258fafc69517df8fddff829bb2a289c1fa4
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='feb7eab99c647a0b4347be9f0a3276de'
 ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-5.9.1-x64.msi'
-ARG teamcityMinimalAgentImage='registry.jetbrains.team/p/tc/docker/teamcity-nightly/teamcity-minimal-agent:153508-nanoserver-2022'
+ARG teamcityMinimalAgentImage='teamcity-minimal-agent:2023.11-nanoserver-2022'
 ARG windowsservercoreImage='mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022'
 
 # The list of required arguments

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -101,6 +101,6 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
+RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount::(OI)(CI)F'
+RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -100,4 +100,7 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -101,6 +101,6 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount::(OI)(CI)F'
-RUN icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
+RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount::(OI)(CI)F'
+RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -6,7 +6,7 @@ ARG gitWindowsComponentSHA256='1905d93068e986258fafc69517df8fddff829bb2a289c1fa4
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='feb7eab99c647a0b4347be9f0a3276de'
 ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-5.9.1-x64.msi'
-ARG teamcityMinimalAgentImage='teamcity-minimal-agent:2023.11-nanoserver-2022'
+ARG teamcityMinimalAgentImage='registry.jetbrains.team/p/tc/docker/teamcity-nightly/teamcity-minimal-agent:153508-nanoserver-2022'
 ARG windowsservercoreImage='mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022'
 
 # The list of required arguments


### PR DESCRIPTION
We copy TeamCity-related folders within the base agent image - `teamcity-minimal-agent`. However, once a new agent is built on top of it, the `permission denied` problem appears.