### PR TITLE
[TCQA] Handle escaping based on PowerShell Module Cache Initialization @ Windows 2022

### DIFF
--- a/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
@@ -96,8 +96,8 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount:(OI)(CI)F'
-RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
@@ -106,6 +106,6 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount:(OI)(CI)F'
-RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
+RUN cmd /c icacls.exe "C:\\BuildAgent\\*" /grant:r 'DefaultAccount:(OI)(CI)F'
+RUN cmd /c icacls.exe "C:\\BuildAgent\\*" /grant:r 'Users:(OI)(CI)F'
 USER ContainerUser

--- a/context/generated/windows/Agent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/2022/Dockerfile
@@ -86,8 +86,8 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount:(OI)(CI)F'
-RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
+RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -101,6 +101,6 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'DefaultAccount:(OI)(CI)F'
-RUN cmd /c icacls.exe "C:\\BuildAgent\\system\\*" /grant:r 'Users:(OI)(CI)F'
+RUN cmd /c icacls.exe "C:\\BuildAgent\\*" /grant:r 'DefaultAccount:(OI)(CI)F'
+RUN cmd /c icacls.exe "C:\\BuildAgent\\*" /grant:r 'Users:(OI)(CI)F'
 USER ContainerUser


### PR DESCRIPTION
Based on the status of PowerShell Module cache, the syntax of`icacls` execution at build time changes. 
When it is initialized, escaping should not be added(`nanoserver`); when it is not, it should be added (`windowsservercore`),  otherwise the build process will fail. 