### PR TITLE
Cherry-pick into 2023.11.x: [TW] Windows 2022 Docker images: update the execution of file permission policies change 

### DIFF
--- a/configs/windows/Agent/nanoserver/NanoServer1803.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer1803.Dockerfile
@@ -52,7 +52,7 @@ VOLUME C:/BuildAgent/conf
 CMD ["pwsh", "./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
-ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
+ENV CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties" \
     # Java home directory
     JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     # Opt out of the telemetry feature

--- a/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
@@ -71,7 +71,7 @@ EXPOSE 9090
 VOLUME C:/BuildAgent/conf
 
     # Configuration file for TeamCity agent
-ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
+ENV CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties" \
     # Java home directory
     JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     # Opt out of the telemetry feature

--- a/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
@@ -76,7 +76,7 @@ EXPOSE 9090
 VOLUME C:/BuildAgent/conf
 
     # Configuration file for TeamCity agent
-ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
+ENV CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties" \
     # Java home directory
     JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     # Opt out of the telemetry feature
@@ -92,12 +92,15 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
     # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
     NUGET_XMLDOC_MODE=skip
 
-# In order to set system PATH, ContainerAdministrator must be used
+# Use ContainerAdministrator to update permissions and PATH
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
-# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete (critical for upgrade), /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\BuildAgent\\*
 USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
@@ -82,7 +82,7 @@ VOLUME C:/BuildAgent/conf
 CMD ["powershell", "./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
-ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
+ENV CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties" \
     # Java home directory
     JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     # Opt out of the telemetry feature

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
@@ -87,7 +87,7 @@ USER ContainerUser
 CMD ["powershell", "./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
-ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
+ENV CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties" \
     # Java home directory
     JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     # Opt out of the telemetry feature
@@ -105,7 +105,10 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
-# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe "C:\\BuildAgent\\*" /grant:r 'DefaultAccount:(OI)(CI)F'
-RUN cmd /c icacls.exe "C:\\BuildAgent\\*" /grant:r 'Users:(OI)(CI)F'
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe "C:\\BuildAgent" /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'DefaultAccount:(OI)(CI)D' /T
+RUN cmd /c icacls.exe "C:\\BuildAgent" /grant:r 'Users:(OI)(CI)F' /grant:r 'Users:(OI)(CI)D' /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\BuildAgent\\*
 USER ContainerUser

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -84,10 +84,14 @@ ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent
 
+# Use ContainerAdministrator to update permissions
 USER ContainerAdministrator
-# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\BuildAgent\\*
 USER ContainerUser
 
 VOLUME C:/BuildAgent/conf

--- a/configs/windows/Server/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer2022.Dockerfile
@@ -118,10 +118,13 @@ VOLUME $TEAMCITY_DATA_PATH \
 
 CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
-# In order to set system PATH, ContainerAdministrator must be used
+# Use ContainerAdministrator to update permissions and PATH
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
-# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe C:\\TeamCity\\* /grant:r DefaultAccount:(OI)(CI)F
-RUN cmd /c icacls.exe C:\\TeamCity\\* /grant:r Users:(OI)(CI)F
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser

--- a/context/generated/windows/Agent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/2022/Dockerfile
@@ -66,7 +66,7 @@ EXPOSE 9090
 VOLUME C:/BuildAgent/conf
 
     # Configuration file for TeamCity agent
-ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
+ENV CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties" \
     # Java home directory
     JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     # Opt out of the telemetry feature
@@ -82,12 +82,15 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
     # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
     NUGET_XMLDOC_MODE=skip
 
-# In order to set system PATH, ContainerAdministrator must be used
+# Use ContainerAdministrator to update permissions and PATH
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Files\dotnet"
-# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete (critical for upgrade), /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\BuildAgent\\*
 USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -82,7 +82,7 @@ USER ContainerUser
 CMD ["powershell", "./BuildAgent/run-agent.ps1"]
 
     # Configuration file for TeamCity agent
-ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
+ENV CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties" \
     # Java home directory
     JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     # Opt out of the telemetry feature
@@ -100,7 +100,10 @@ ENV CONFIG_FILE="C:/BuildAgent/conf/buildAgent.properties" \
 
 USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME)
-# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe "C:\\BuildAgent\\*" /grant:r 'DefaultAccount:(OI)(CI)F'
-RUN cmd /c icacls.exe "C:\\BuildAgent\\*" /grant:r 'Users:(OI)(CI)F'
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe "C:\\BuildAgent" /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'DefaultAccount:(OI)(CI)D' /T
+RUN cmd /c icacls.exe "C:\\BuildAgent" /grant:r 'Users:(OI)(CI)F' /grant:r 'Users:(OI)(CI)D' /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\BuildAgent\\*
 USER ContainerUser

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -77,10 +77,14 @@ ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent
 
+# Use ContainerAdministrator to update permissions
 USER ContainerAdministrator
-# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r DefaultAccount:(OI)(CI)F
-RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\BuildAgent\\*
 USER ContainerUser
 
 VOLUME C:/BuildAgent/conf

--- a/context/generated/windows/Server/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/2022/Dockerfile
@@ -114,10 +114,13 @@ VOLUME $TEAMCITY_DATA_PATH \
 
 CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
-# In order to set system PATH, ContainerAdministrator must be used
+# Use ContainerAdministrator to update permissions and PATH
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
-# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Contaiber Inherit, F - full control
-RUN cmd /c icacls.exe C:\\TeamCity\\* /grant:r DefaultAccount:(OI)(CI)F
-RUN cmd /c icacls.exe C:\\TeamCity\\* /grant:r Users:(OI)(CI)F
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser


### PR DESCRIPTION
Pull request is dedicated to cherry-pick the changes from https://github.com/JetBrains/teamcity-docker-images/pull/141 into `development/2023.11.x` branch.