### PR TITLE
[TCQA] Remove out-of-support docker-compose V1, replacing with compose plugin bundled into "docker-ce-cli"

### DIFF
--- a/configs/linux.config
+++ b/configs/linux.config
@@ -29,7 +29,7 @@ dockerComposeLinuxComponentVersion=1.28.5
 dockerLinuxComponentVersion=5:24.0.9-1~ubuntu
 dockerLinuxComponentName=[Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 
-containerdIoLinuxComponentName=[Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
+containerdIoLinuxComponentName=[Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 containerdIoLinuxComponentVersion=1.6.28-2
 
 # https://www.perforce.com/perforce-packages

--- a/configs/linux.config
+++ b/configs/linux.config
@@ -30,7 +30,7 @@ dockerLinuxComponentVersion=5:25.0.5-1~ubuntu
 dockerLinuxComponentName=[Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
 
 containerdIoLinuxComponentName=[Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
-containerdIoLinuxComponentVersion=1.4.12-1
+containerdIoLinuxComponentVersion=1.6.28-2
 
 # https://www.perforce.com/perforce-packages
 # https://package.perforce.com/apt/ubuntu/dists/focal/release/binary-amd64/Packages

--- a/configs/linux.config
+++ b/configs/linux.config
@@ -26,8 +26,8 @@ gitLFSLinuxComponentVersion=2.9.2-1
 gitLFSLinuxComponentName=Git LFS v.2.9.2
 
 dockerComposeLinuxComponentVersion=1.28.5
-dockerLinuxComponentVersion=5:24.0.2-1~ubuntu
-dockerLinuxComponentName=[Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
+dockerLinuxComponentVersion=5:25.0.5-1~ubuntu
+dockerLinuxComponentName=[Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
 
 containerdIoLinuxComponentName=[Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 containerdIoLinuxComponentVersion=1.4.12-1

--- a/configs/linux.config
+++ b/configs/linux.config
@@ -26,8 +26,8 @@ gitLFSLinuxComponentVersion=2.9.2-1
 gitLFSLinuxComponentName=Git LFS v.2.9.2
 
 dockerComposeLinuxComponentVersion=1.28.5
-dockerLinuxComponentVersion=5:20.10.12~3-0~ubuntu
-dockerLinuxComponentName=[Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12)
+dockerLinuxComponentVersion=5:24.0.2-1~ubuntu
+dockerLinuxComponentName=[Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
 
 containerdIoLinuxComponentName=[Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 containerdIoLinuxComponentVersion=1.4.12-1

--- a/configs/linux.config
+++ b/configs/linux.config
@@ -26,8 +26,8 @@ gitLFSLinuxComponentVersion=2.9.2-1
 gitLFSLinuxComponentName=Git LFS v.2.9.2
 
 dockerComposeLinuxComponentVersion=1.28.5
-dockerLinuxComponentVersion=5:25.0.5-1~ubuntu
-dockerLinuxComponentName=[Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
+dockerLinuxComponentVersion=5:26.0.0-1~ubuntu
+dockerLinuxComponentName=[Docker v.5:26.0.0](https://docs.docker.com/engine/release-notes/26.0)
 
 containerdIoLinuxComponentName=[Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 containerdIoLinuxComponentVersion=1.6.28-2

--- a/configs/linux.config
+++ b/configs/linux.config
@@ -26,8 +26,8 @@ gitLFSLinuxComponentVersion=2.9.2-1
 gitLFSLinuxComponentName=Git LFS v.2.9.2
 
 dockerComposeLinuxComponentVersion=1.28.5
-dockerLinuxComponentVersion=5:26.0.0-1~ubuntu
-dockerLinuxComponentName=[Docker v.5:26.0.0](https://docs.docker.com/engine/release-notes/26.0)
+dockerLinuxComponentVersion=5:24.0.9-1~ubuntu
+dockerLinuxComponentName=[Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 
 containerdIoLinuxComponentName=[Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 containerdIoLinuxComponentVersion=1.6.28-2

--- a/configs/linux.config
+++ b/configs/linux.config
@@ -25,7 +25,6 @@ gitLinuxComponentName=Git v.2.43.2
 gitLFSLinuxComponentVersion=2.9.2-1
 gitLFSLinuxComponentName=Git LFS v.2.9.2
 
-dockerComposeLinuxComponentVersion=1.28.5
 dockerLinuxComponentVersion=5:24.0.9-1~ubuntu
 dockerLinuxComponentName=[Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 

--- a/configs/linux/Agent/Ubuntu/Ubuntu-sudo.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu-sudo.Dockerfile
@@ -16,7 +16,6 @@
 # @AddToolToDoc ${gitLinuxComponentName}
 # @AddToolToDoc Mercurial
 # @AddToolToDoc ${dockerLinuxComponentName}
-# @AddToolToDoc [Docker Compose v.${dockerComposeLinuxComponentVersion}](https://github.com/docker/compose/releases/tag/${dockerComposeLinuxComponentVersion})
 # @AddToolToDoc ${containerdIoLinuxComponentName}
 # @AddToolToDoc [${dotnetLinuxComponentName}](${dotnetLinuxComponent})
 # @AddToolToDoc ${p4Name}

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -88,10 +88,11 @@ RUN apt-get update && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-cache policy docker-ce && \
     apt-get update && \
-    apt-get install -y  docker-ce=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-                        docker-ce-cli=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-                        containerd.io:amd64=${containerdIoLinuxComponentVersion} \
-                        systemd && \
+    # docker-ce, docker-ce-cli package name format: "25.0.5-1~ubuntu.20.04~focal"
+    apt-get install -y docker-ce=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+        docker-ce-cli=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+        containerd.io:amd64=${containerdIoLinuxComponentVersion} \
+        systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
 # Docker Compose

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -5,7 +5,6 @@
 # ARG dotnetLibs
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
-# ARG dockerComposeLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
 
 # Id teamcity-agent
@@ -27,7 +26,6 @@
 # @AddToolToDoc ${gitLinuxComponentName}
 # @AddToolToDoc Mercurial
 # @AddToolToDoc ${dockerLinuxComponentName}
-# @AddToolToDoc [Docker Compose v.${dockerComposeLinuxComponentVersion}](https://github.com/docker/compose/releases/tag/${dockerComposeLinuxComponentVersion})
 # @AddToolToDoc ${containerdIoLinuxComponentName}
 # @AddToolToDoc [${dotnetLinuxComponentName}](${dotnetLinuxComponent})
 # @AddToolToDoc ${p4Name}
@@ -62,7 +60,6 @@ ARG dotnetLinuxComponentSHA512
 ARG dotnetLibs
 ARG gitLinuxComponentVersion
 ARG gitLFSLinuxComponentVersion
-ARG dockerComposeLinuxComponentVersion
 ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
@@ -95,8 +92,6 @@ RUN apt-get update && \
         systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
-# Docker Compose
-    curl -SL "https://github.com/docker/compose/releases/download/${dockerComposeLinuxComponentVersion}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && \
 # Dotnet
     apt-get install -y --no-install-recommends ${dotnetLibs} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM-sudo.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM-sudo.Dockerfile
@@ -17,7 +17,6 @@
 # @AddToolToDoc Mercurial
 # @AddToolToDoc ${dockerLinuxComponentName}
 # @AddToolToDoc ${containerdIoLinuxComponentName}
-# @AddToolToDoc [Docker Compose v.${dockerComposeLinuxComponentVersion}](https://github.com/docker/compose/releases/tag/${dockerComposeLinuxComponentVersion})
 # @AddToolToDoc [${dotnetLinuxARM64ComponentName}](${dotnetLinuxARM64Component})
 
 

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -5,7 +5,6 @@
 # ARG dotnetLibs
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
-# ARG dockerComposeLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
 
 # Id teamcity-agent
@@ -26,7 +25,6 @@
 # @AddToolToDoc Mercurial
 # @AddToolToDoc ${dockerLinuxComponentName}
 # @AddToolToDoc ${containerdIoLinuxComponentName}
-# @AddToolToDoc [Docker Compose v.${dockerComposeLinuxComponentVersion}](https://github.com/docker/compose/releases/tag/${dockerComposeLinuxComponentVersion})
 # @AddToolToDoc [${dotnetLinuxARM64ComponentName}](${dotnetLinuxARM64Component})
 
 
@@ -59,7 +57,6 @@ ARG dotnetLinuxARM64ComponentSHA512
 ARG dotnetLibs
 ARG gitLinuxComponentVersion
 ARG gitLFSLinuxComponentVersion
-ARG dockerComposeLinuxComponentVersion
 ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 
@@ -82,8 +79,6 @@ RUN apt-get update && \
       systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
-# Docker-Compose
-    curl -SL "https://github.com/docker/compose/releases/download/${dockerComposeLinuxComponentVersion}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -75,10 +75,11 @@ RUN apt-get update && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-cache policy docker-ce && \
     apt-get update && \
-    apt-get install -y  docker-ce=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-    docker-ce-cli=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-    containerd.io:arm64=${containerdIoLinuxComponentVersion} \
-    systemd && \
+    # docker-ce, docker-ce-cli package name format: "26.0.0-1~ubuntu.20.04~focal"
+    apt-get install -y docker-ce=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+      docker-ce-cli=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+      containerd.io:arm64=${containerdIoLinuxComponentVersion} \
+      systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
 # Docker-Compose

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:26.0.0-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:24.0.9-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -1,5 +1,5 @@
 # Default arguments
-ARG containerdIoLinuxComponentVersion='1.4.12-1'
+ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
 ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.4.12-1'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:20.10.12~3-0~ubuntu'
+ARG dockerLinuxComponentVersion='5:24.0.2-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:26.0.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -1,6 +1,5 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
-ARG dockerComposeLinuxComponentVersion='1.28.5'
 ARG dockerLinuxComponentVersion='5:24.0.9-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
@@ -18,7 +17,6 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-18.04'
 # ARG dotnetLibs
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
-# ARG dockerComposeLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
 
 
@@ -54,7 +52,6 @@ ARG dotnetLinuxComponentSHA512
 ARG dotnetLibs
 ARG gitLinuxComponentVersion
 ARG gitLFSLinuxComponentVersion
-ARG dockerComposeLinuxComponentVersion
 ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
@@ -87,8 +84,6 @@ RUN apt-get update && \
         systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
-# Docker Compose
-    curl -SL "https://github.com/docker/compose/releases/download/${dockerComposeLinuxComponentVersion}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && \
 # Dotnet
     apt-get install -y --no-install-recommends ${dotnetLibs} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.4.12-1'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:24.0.2-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -80,10 +80,11 @@ RUN apt-get update && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-cache policy docker-ce && \
     apt-get update && \
-    apt-get install -y  docker-ce=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-                        docker-ce-cli=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-                        containerd.io:amd64=${containerdIoLinuxComponentVersion} \
-                        systemd && \
+    # docker-ce, docker-ce-cli package name format: "25.0.5-1~ubuntu.20.04~focal"
+    apt-get install -y docker-ce=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+        docker-ce-cli=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+        containerd.io:amd64=${containerdIoLinuxComponentVersion} \
+        systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
 # Docker Compose

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.4.12-1'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:20.10.12~3-0~ubuntu'
+ARG dockerLinuxComponentVersion='5:24.0.2-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:26.0.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -1,5 +1,5 @@
 # Default arguments
-ARG containerdIoLinuxComponentVersion='1.4.12-1'
+ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
 ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.4.12-1'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:24.0.2-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -80,10 +80,11 @@ RUN apt-get update && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-cache policy docker-ce && \
     apt-get update && \
-    apt-get install -y  docker-ce=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-                        docker-ce-cli=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-                        containerd.io:amd64=${containerdIoLinuxComponentVersion} \
-                        systemd && \
+    # docker-ce, docker-ce-cli package name format: "25.0.5-1~ubuntu.20.04~focal"
+    apt-get install -y docker-ce=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+        docker-ce-cli=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+        containerd.io:amd64=${containerdIoLinuxComponentVersion} \
+        systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
 # Docker Compose

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:26.0.0-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:24.0.9-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -1,6 +1,5 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
-ARG dockerComposeLinuxComponentVersion='1.28.5'
 ARG dockerLinuxComponentVersion='5:24.0.9-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
@@ -18,7 +17,6 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 # ARG dotnetLibs
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
-# ARG dockerComposeLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
 
 
@@ -54,7 +52,6 @@ ARG dotnetLinuxComponentSHA512
 ARG dotnetLibs
 ARG gitLinuxComponentVersion
 ARG gitLFSLinuxComponentVersion
-ARG dockerComposeLinuxComponentVersion
 ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
@@ -87,8 +84,6 @@ RUN apt-get update && \
         systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
-# Docker Compose
-    curl -SL "https://github.com/docker/compose/releases/download/${dockerComposeLinuxComponentVersion}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && \
 # Dotnet
     apt-get install -y --no-install-recommends ${dotnetLibs} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -1,5 +1,5 @@
 # Default arguments
-ARG containerdIoLinuxComponentVersion='1.4.12-1'
+ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
 ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:26.0.0-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:24.0.9-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759'

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.4.12-1'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:24.0.2-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759'

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -1,6 +1,5 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
-ARG dockerComposeLinuxComponentVersion='1.28.5'
 ARG dockerLinuxComponentVersion='5:24.0.9-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
@@ -17,7 +16,6 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64-18.04'
 # ARG dotnetLibs
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
-# ARG dockerComposeLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
 
 
@@ -53,7 +51,6 @@ ARG dotnetLinuxARM64ComponentSHA512
 ARG dotnetLibs
 ARG gitLinuxComponentVersion
 ARG gitLFSLinuxComponentVersion
-ARG dockerComposeLinuxComponentVersion
 ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 
@@ -76,8 +73,6 @@ RUN apt-get update && \
       systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
-# Docker-Compose
-    curl -SL "https://github.com/docker/compose/releases/download/${dockerComposeLinuxComponentVersion}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -69,10 +69,11 @@ RUN apt-get update && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-cache policy docker-ce && \
     apt-get update && \
-    apt-get install -y  docker-ce=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-    docker-ce-cli=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-    containerd.io:arm64=${containerdIoLinuxComponentVersion} \
-    systemd && \
+    # docker-ce, docker-ce-cli package name format: "26.0.0-1~ubuntu.20.04~focal"
+    apt-get install -y docker-ce=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+      docker-ce-cli=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+      containerd.io:arm64=${containerdIoLinuxComponentVersion} \
+      systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
 # Docker-Compose

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.4.12-1'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:20.10.12~3-0~ubuntu'
+ARG dockerLinuxComponentVersion='5:24.0.2-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759'

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:26.0.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759'

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.4.12-1'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:24.0.2-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759'

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:26.0.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759'

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:26.0.0-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:24.0.9-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759'

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.4.12-1'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
-ARG dockerLinuxComponentVersion='5:20.10.12~3-0~ubuntu'
+ARG dockerLinuxComponentVersion='5:24.0.2-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759'

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -69,10 +69,11 @@ RUN apt-get update && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-cache policy docker-ce && \
     apt-get update && \
-    apt-get install -y  docker-ce=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-    docker-ce-cli=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-    containerd.io:arm64=${containerdIoLinuxComponentVersion} \
-    systemd && \
+    # docker-ce, docker-ce-cli package name format: "26.0.0-1~ubuntu.20.04~focal"
+    apt-get install -y docker-ce=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+      docker-ce-cli=${dockerLinuxComponentVersion}.$(lsb_release -rs)~$(lsb_release -cs) \
+      containerd.io:arm64=${containerdIoLinuxComponentVersion} \
+      systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
 # Docker-Compose

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -1,6 +1,5 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
-ARG dockerComposeLinuxComponentVersion='1.28.5'
 ARG dockerLinuxComponentVersion='5:24.0.9-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
@@ -17,7 +16,6 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64'
 # ARG dotnetLibs
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
-# ARG dockerComposeLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
 
 
@@ -53,7 +51,6 @@ ARG dotnetLinuxARM64ComponentSHA512
 ARG dotnetLibs
 ARG gitLinuxComponentVersion
 ARG gitLFSLinuxComponentVersion
-ARG dockerComposeLinuxComponentVersion
 ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 
@@ -76,8 +73,6 @@ RUN apt-get update && \
       systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
-# Docker-Compose
-    curl -SL "https://github.com/docker/compose/releases/download/${dockerComposeLinuxComponentVersion}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -1,5 +1,5 @@
 # Default arguments
-ARG containerdIoLinuxComponentVersion='1.4.12-1'
+ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerComposeLinuxComponentVersion='1.28.5'
 ARG dockerLinuxComponentVersion='5:25.0.5-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -93,9 +93,9 @@ Installed components:
 - Git LFS v.2.9.2
 - Git v.2.43.2
 - Mercurial
-- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
+- [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
-- [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
+- [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2531894](https://www.perforce.com/products/helix-core)
 
@@ -133,8 +133,8 @@ Installed components:
 - Git v.2.43.2
 - Git LFS v.2.9.2
 - Mercurial
-- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
-- [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
+- [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
+- [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
 
@@ -173,8 +173,8 @@ Installed components:
 - Git v.2.43.2
 - Git LFS v.2.9.2
 - Mercurial
-- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
-- [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
+- [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
+- [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
 
@@ -214,9 +214,9 @@ Installed components:
 - Git LFS v.2.9.2
 - Git v.2.43.2
 - Mercurial
-- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
+- [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
-- [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
+- [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2531894](https://www.perforce.com/products/helix-core)
 
@@ -394,9 +394,9 @@ Installed components:
 - Git LFS v.2.3.4
 - Git v.2.41.0
 - Mercurial
-- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
+- [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
-- [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
+- [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2531894](https://www.perforce.com/products/helix-core)
 
@@ -432,9 +432,9 @@ Installed components:
 - Git LFS v.2.9.2
 - Git v.2.43.2
 - Mercurial
-- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
+- [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
-- [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
+- [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2531894](https://www.perforce.com/products/helix-core)
 
@@ -470,8 +470,8 @@ Installed components:
 - Git v.2.41.0
 - Git LFS v.2.3.4
 - Mercurial
-- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
-- [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
+- [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
+- [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
 
@@ -507,8 +507,8 @@ Installed components:
 - Git v.2.43.2
 - Git LFS v.2.9.2
 - Mercurial
-- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
-- [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
+- [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
+- [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
 

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -93,7 +93,7 @@ Installed components:
 - Git LFS v.2.9.2
 - Git v.2.43.2
 - Mercurial
-- [Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12)
+- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
@@ -133,7 +133,7 @@ Installed components:
 - Git v.2.43.2
 - Git LFS v.2.9.2
 - Mercurial
-- [Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12)
+- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
@@ -173,7 +173,7 @@ Installed components:
 - Git v.2.43.2
 - Git LFS v.2.9.2
 - Mercurial
-- [Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12)
+- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
@@ -214,7 +214,7 @@ Installed components:
 - Git LFS v.2.9.2
 - Git v.2.43.2
 - Mercurial
-- [Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12)
+- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
@@ -394,7 +394,7 @@ Installed components:
 - Git LFS v.2.3.4
 - Git v.2.41.0
 - Mercurial
-- [Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12)
+- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
@@ -432,7 +432,7 @@ Installed components:
 - Git LFS v.2.9.2
 - Git v.2.43.2
 - Mercurial
-- [Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12)
+- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
@@ -470,7 +470,7 @@ Installed components:
 - Git v.2.41.0
 - Git LFS v.2.3.4
 - Mercurial
-- [Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12)
+- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
@@ -507,7 +507,7 @@ Installed components:
 - Git v.2.43.2
 - Git LFS v.2.9.2
 - Mercurial
-- [Docker v.5:20.10.12](https://github.com/docker/cli/releases/tag/v20.10.12)
+- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -93,7 +93,7 @@ Installed components:
 - Git LFS v.2.9.2
 - Git v.2.43.2
 - Mercurial
-- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
+- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
@@ -133,7 +133,7 @@ Installed components:
 - Git v.2.43.2
 - Git LFS v.2.9.2
 - Mercurial
-- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
+- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
@@ -173,7 +173,7 @@ Installed components:
 - Git v.2.43.2
 - Git LFS v.2.9.2
 - Mercurial
-- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
+- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
@@ -214,7 +214,7 @@ Installed components:
 - Git LFS v.2.9.2
 - Git v.2.43.2
 - Mercurial
-- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
+- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
@@ -394,7 +394,7 @@ Installed components:
 - Git LFS v.2.3.4
 - Git v.2.41.0
 - Mercurial
-- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
+- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
@@ -432,7 +432,7 @@ Installed components:
 - Git LFS v.2.9.2
 - Git v.2.43.2
 - Mercurial
-- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
+- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
@@ -470,7 +470,7 @@ Installed components:
 - Git v.2.41.0
 - Git LFS v.2.3.4
 - Mercurial
-- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
+- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
@@ -507,7 +507,7 @@ Installed components:
 - Git v.2.43.2
 - Git LFS v.2.9.2
 - Mercurial
-- [Docker v.5:24.0.2](https://docs.docker.com/engine/release-notes/24.0)
+- [Docker v.5:25.0.5](https://docs.docker.com/engine/release-notes/25.0)
 - [Containerd.io v1.4.12-1](https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/containerd.io_1.4.12-1_amd64.deb.html)
 - [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -94,7 +94,6 @@ Installed components:
 - Git v.2.43.2
 - Mercurial
 - [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
-- [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2531894](https://www.perforce.com/products/helix-core)
@@ -135,7 +134,6 @@ Installed components:
 - Mercurial
 - [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
-- [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
 
 Container platform: linux
@@ -175,7 +173,6 @@ Installed components:
 - Mercurial
 - [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
-- [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
 
 Container platform: linux
@@ -215,7 +212,6 @@ Installed components:
 - Git v.2.43.2
 - Mercurial
 - [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
-- [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2531894](https://www.perforce.com/products/helix-core)
@@ -395,7 +391,6 @@ Installed components:
 - Git v.2.41.0
 - Mercurial
 - [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
-- [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2531894](https://www.perforce.com/products/helix-core)
@@ -433,7 +428,6 @@ Installed components:
 - Git v.2.43.2
 - Mercurial
 - [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
-- [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2531894](https://www.perforce.com/products/helix-core)
@@ -472,7 +466,6 @@ Installed components:
 - Mercurial
 - [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
-- [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
 
 Container platform: linux
@@ -509,7 +502,6 @@ Installed components:
 - Mercurial
 - [Docker v.5:24.0.9](https://docs.docker.com/engine/release-notes/24.0)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
-- [Docker Compose v.1.28.5](https://github.com/docker/compose/releases/tag/1.28.5)
 - [.NET SDK v.6.0.413 (LTS) ARM64 Checksum (SHA512) 7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz)
 
 Container platform: linux


### PR DESCRIPTION
Pull request is dedicated to the removal of `docker-compose` V1, which, according to Docker's [Docker Compose overview](https://docs.docker.com/compose/), is no longer receiving updates:

```
Effective July 2023, Compose V1 stopped receiving updates and is no longer in new Docker Desktop releases
```

`docker compose` plugin is bundled into `docker-ce-cli` currently available within the images. 

TeamCity supports both implementations.

