### PR TITLE
[TW-87124] Enforce case sensitivity within Windows 2022 Docker Images

### DIFF
--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -28,6 +28,10 @@ USER ContainerAdministrator
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# CaseSensitivity is essential for the agent => enforcing it
+RUN mkdir C:\\BuildAgent
+RUN fsutil.exe file SetCaseSensitiveInfo C:\\BuildAgent enable
+
 # Prepare build agent distribution
 COPY TeamCity/buildAgent C:/BuildAgent
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -28,9 +28,9 @@ USER ContainerAdministrator
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# CaseSensitivity is essential for the agent => enforcing it
+# CaseSensitivity is essential for the agent => enforcing it. PowerShell env is required
 RUN mkdir C:\\BuildAgent
-RUN fsutil.exe file SetCaseSensitiveInfo C:\\BuildAgent enable
+RUN pwsh -c 'fsutil.exe file SetCaseSensitiveInfo C:\\BuildAgent enable'
 
 # Prepare build agent distribution
 COPY TeamCity/buildAgent C:/BuildAgent

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -28,9 +28,9 @@ USER ContainerAdministrator
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# CaseSensitivity is essential for the agent => enforcing it. PowerShell env is required
+# CaseSensitivity is essential for the agent => enforcing it. SHELL usage is mandatory (pwsh or other won't work)
 RUN mkdir C:\\BuildAgent
-RUN pwsh -c 'fsutil.exe file SetCaseSensitiveInfo C:\\BuildAgent enable'
+SHELL ["pwsh", "-Command", "fsutil.exe", "file", "SetCaseSensitiveInfo", "C:\\BuildAgent", "enable"]
 
 # Prepare build agent distribution
 COPY TeamCity/buildAgent C:/BuildAgent

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -22,9 +22,9 @@ USER ContainerAdministrator
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# CaseSensitivity is essential for the agent => enforcing it. PowerShell env is required
+# CaseSensitivity is essential for the agent => enforcing it. SHELL usage is mandatory (pwsh or other won't work)
 RUN mkdir C:\\BuildAgent
-RUN pwsh -c 'fsutil.exe file SetCaseSensitiveInfo C:\\BuildAgent enable'
+SHELL ["pwsh", "-Command", "fsutil.exe", "file", "SetCaseSensitiveInfo", "C:\\BuildAgent", "enable"]
 
 # Prepare build agent distribution
 COPY TeamCity/buildAgent C:/BuildAgent

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -22,9 +22,9 @@ USER ContainerAdministrator
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# CaseSensitivity is essential for the agent => enforcing it
+# CaseSensitivity is essential for the agent => enforcing it. PowerShell env is required
 RUN mkdir C:\\BuildAgent
-RUN fsutil.exe file SetCaseSensitiveInfo C:\\BuildAgent enable
+RUN pwsh -c 'fsutil.exe file SetCaseSensitiveInfo C:\\BuildAgent enable'
 
 # Prepare build agent distribution
 COPY TeamCity/buildAgent C:/BuildAgent

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -22,6 +22,10 @@ USER ContainerAdministrator
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# CaseSensitivity is essential for the agent => enforcing it
+RUN mkdir C:\\BuildAgent
+RUN fsutil.exe file SetCaseSensitiveInfo C:\\BuildAgent enable
+
 # Prepare build agent distribution
 COPY TeamCity/buildAgent C:/BuildAgent
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1


### PR DESCRIPTION
Pull request is aimed at enforcing case sensitivity within Windows 2022-based TeamCity Docker Images. This is necessary because the BuildAgent folder contains directories whose names are treated as case-sensitive by the application. 