### PR TITLE
[TW-87124] Windows 2022-based Agent Images become incompatible with some runners after restart

### DIFF
--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -34,6 +34,11 @@ SHELL ["pwsh", "-Command", "fsutil.exe", "file", "SetCaseSensitiveInfo", "C:\\Bu
 
 # Prepare build agent distribution
 COPY TeamCity/buildAgent C:/BuildAgent
+
+# Workaround for TW-87124 - Windows 2022-based plugin directories receive incorrect case, causing their inability ...
+# ... to load. The directory will be fetched from the server upon the first update with proper case.
+RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
+
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -28,11 +28,8 @@ USER ContainerAdministrator
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# CaseSensitivity is essential for the agent => enforcing it. SHELL usage is mandatory (pwsh or other won't work)
-RUN mkdir C:\\BuildAgent
-SHELL ["pwsh", "-Command", "fsutil.exe", "file", "SetCaseSensitiveInfo", "C:\\BuildAgent", "enable"]
-
 # Prepare build agent distribution
+RUN mkdir C:\\BuildAgent
 COPY TeamCity/buildAgent C:/BuildAgent
 
 # Workaround for TW-87124 - Windows 2022-based plugin directories receive incorrect case, causing their inability ...

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -28,7 +28,8 @@ RUN mkdir C:\\BuildAgent
 # Prepare build agent distribution
 COPY TeamCity/buildAgent C:/BuildAgent
 
-# Workaround for plugin case sensitivity
+# Workaround for TW-87124 - Windows 2022-based plugin directories receive incorrect case, causing their inability ...
+# ... to load. The directory will be fetched from the server upon the first update with proper case.
 RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
 
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -24,10 +24,13 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 
 # CaseSensitivity is essential for the agent => enforcing it. SHELL usage is mandatory (pwsh or other won't work)
 RUN mkdir C:\\BuildAgent
-SHELL ["pwsh", "-Command", "fsutil.exe", "file", "SetCaseSensitiveInfo", "C:\\BuildAgent", "enable"]
 
 # Prepare build agent distribution
 COPY TeamCity/buildAgent C:/BuildAgent
+
+# Workaround for plugin case sensitivity
+RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
+
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -22,10 +22,8 @@ USER ContainerAdministrator
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# CaseSensitivity is essential for the agent => enforcing it. SHELL usage is mandatory (pwsh or other won't work)
-RUN mkdir C:\\BuildAgent
-
 # Prepare build agent distribution
+RUN mkdir C:\\BuildAgent
 COPY TeamCity/buildAgent C:/BuildAgent
 
 # Workaround for TW-87124 - Windows 2022-based plugin directories receive incorrect case, causing their inability ...


### PR DESCRIPTION
**Problem**

Windows 2022-based images become incompatible after the restart caused by the initial upgrade. The incompatibility is caused by the fact the plugin directories, which are being re-created upon the upgrade, receive the name in lowercase.
1. Upgrade, along with `plugins.zip`, is downloaded.
2. `plugins.zip` archive, containing the updated plugins, is extracted onto `C:\BuildAgent\plugins\` directory. Example: `testNGPlugin.zip`, `antPlugin.zip`, etc.
3. Plugins, which contains upper-cased letters in their names (such as `antPlugin`) are extracted into directories with lower-cased names, such as `antplugin`.
4. If a user will create the directory directly via PowerShell (`mkdir antPlugin`), it will also be created in lowercase (`antplugin`), while the custom directory (`customDirectory`) will be created in a proper case.
5. The attributes of "problametic" and "non-problematic" directories are equal, as well as the attributes of zip files and relacted folders.

**Pull request** is dedicated to the temporary removal of `plugins` directory. Once it will be created by the agent upon the first upgrade, the case problem won't be observed there.

Utilities that could adjust this behavior (e.g. path normalization), such as `fsutil.exe`, are not avaialble within nanoserver images.