### PR TITLE
[TW] Adjust Windows 2019 Dockerfiles to infrastructure changes

### DIFF
--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
@@ -21,11 +21,17 @@
 # Based on ${powershellImage} 3
 FROM ${powershellImage} AS base
 
+# On some agents, Windows 2019 requires administrator permissions to modify "C:/" folder within ...
+# ... PowerShell container.
+USER ContainerAdministrator
+
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Prepare build agent distribution
+RUN mkdir C:\\BuildAgent
 COPY TeamCity/buildAgent C:/BuildAgent
+
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK
@@ -79,6 +85,16 @@ ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent
+
+# Use ContainerAdministrator to update permissions
+USER ContainerAdministrator
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\BuildAgent\\*
+USER ContainerUser
 
 VOLUME C:/BuildAgent/conf
 VOLUME C:/BuildAgent/work

--- a/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
@@ -26,6 +26,10 @@
 # PowerShell
 FROM ${powershellImage} AS base
 
+# On some agents, Windows 2019 requires administrator permissions to modify "C:/" folder within ...
+# ... PowerShell container.
+USER ContainerAdministrator
+
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -57,6 +61,8 @@ ARG windowsBuild
 COPY TeamCity /TeamCity
 RUN New-Item C:/TeamCity/webapps/ROOT/WEB-INF/DistributionType.txt -type file -force -value "docker-windows-$Env:windowsBuild" | Out-Null
 COPY run-server.ps1 /TeamCity/run-server.ps1
+
+USER ContainerUser
 
 # Workaround for https://github.com/PowerShell/PowerShell-Docker/issues/164
 ARG nanoserverImage
@@ -108,7 +114,13 @@ VOLUME $TEAMCITY_DATA_PATH \
 
 CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
-# In order to set system PATH, ContainerAdministrator must be used
+# Use ContainerAdministrator to update permissions and PATH
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser

--- a/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
@@ -15,11 +15,17 @@ ARG powershellImage='mcr.microsoft.com/powershell:nanoserver-1809'
 
 FROM ${powershellImage} AS base
 
+# On some agents, Windows 2019 requires administrator permissions to modify "C:/" folder within ...
+# ... PowerShell container.
+USER ContainerAdministrator
+
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Prepare build agent distribution
+RUN mkdir C:\\BuildAgent
 COPY TeamCity/buildAgent C:/BuildAgent
+
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK
@@ -72,6 +78,16 @@ ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent
+
+# Use ContainerAdministrator to update permissions
+USER ContainerAdministrator
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\BuildAgent\\*
+USER ContainerUser
 
 VOLUME C:/BuildAgent/conf
 VOLUME C:/BuildAgent/work

--- a/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
@@ -15,11 +15,17 @@ ARG powershellImage='mcr.microsoft.com/powershell:nanoserver-1909'
 
 FROM ${powershellImage} AS base
 
+# On some agents, Windows 2019 requires administrator permissions to modify "C:/" folder within ...
+# ... PowerShell container.
+USER ContainerAdministrator
+
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Prepare build agent distribution
+RUN mkdir C:\\BuildAgent
 COPY TeamCity/buildAgent C:/BuildAgent
+
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK
@@ -72,6 +78,16 @@ ENV JAVA_HOME="C:\Program Files\Java\OpenJDK" \
     CONFIG_FILE="C:\BuildAgent\conf\buildAgent.properties"
 
 COPY --chown=ContainerUser --from=base /BuildAgent /BuildAgent
+
+# Use ContainerAdministrator to update permissions
+USER ContainerAdministrator
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\BuildAgent /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\BuildAgent\\*
+USER ContainerUser
 
 VOLUME C:/BuildAgent/conf
 VOLUME C:/BuildAgent/work

--- a/context/generated/windows/Server/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1809/Dockerfile
@@ -22,6 +22,10 @@ ARG windowsBuild='1809'
 # PowerShell
 FROM ${powershellImage} AS base
 
+# On some agents, Windows 2019 requires administrator permissions to modify "C:/" folder within ...
+# ... PowerShell container.
+USER ContainerAdministrator
+
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -53,6 +57,8 @@ ARG windowsBuild
 COPY TeamCity /TeamCity
 RUN New-Item C:/TeamCity/webapps/ROOT/WEB-INF/DistributionType.txt -type file -force -value "docker-windows-$Env:windowsBuild" | Out-Null
 COPY run-server.ps1 /TeamCity/run-server.ps1
+
+USER ContainerUser
 
 # Workaround for https://github.com/PowerShell/PowerShell-Docker/issues/164
 ARG nanoserverImage
@@ -104,7 +110,13 @@ VOLUME $TEAMCITY_DATA_PATH \
 
 CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
-# In order to set system PATH, ContainerAdministrator must be used
+# Use ContainerAdministrator to update permissions and PATH
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser

--- a/context/generated/windows/Server/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1903/Dockerfile
@@ -22,6 +22,10 @@ ARG windowsBuild='1903'
 # PowerShell
 FROM ${powershellImage} AS base
 
+# On some agents, Windows 2019 requires administrator permissions to modify "C:/" folder within ...
+# ... PowerShell container.
+USER ContainerAdministrator
+
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -53,6 +57,8 @@ ARG windowsBuild
 COPY TeamCity /TeamCity
 RUN New-Item C:/TeamCity/webapps/ROOT/WEB-INF/DistributionType.txt -type file -force -value "docker-windows-$Env:windowsBuild" | Out-Null
 COPY run-server.ps1 /TeamCity/run-server.ps1
+
+USER ContainerUser
 
 # Workaround for https://github.com/PowerShell/PowerShell-Docker/issues/164
 ARG nanoserverImage
@@ -104,7 +110,13 @@ VOLUME $TEAMCITY_DATA_PATH \
 
 CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
-# In order to set system PATH, ContainerAdministrator must be used
+# Use ContainerAdministrator to update permissions and PATH
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser

--- a/context/generated/windows/Server/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1909/Dockerfile
@@ -22,6 +22,10 @@ ARG windowsBuild='1909'
 # PowerShell
 FROM ${powershellImage} AS base
 
+# On some agents, Windows 2019 requires administrator permissions to modify "C:/" folder within ...
+# ... PowerShell container.
+USER ContainerAdministrator
+
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -53,6 +57,8 @@ ARG windowsBuild
 COPY TeamCity /TeamCity
 RUN New-Item C:/TeamCity/webapps/ROOT/WEB-INF/DistributionType.txt -type file -force -value "docker-windows-$Env:windowsBuild" | Out-Null
 COPY run-server.ps1 /TeamCity/run-server.ps1
+
+USER ContainerUser
 
 # Workaround for https://github.com/PowerShell/PowerShell-Docker/issues/164
 ARG nanoserverImage
@@ -104,7 +110,13 @@ VOLUME $TEAMCITY_DATA_PATH \
 
 CMD ["pwsh", "C:/TeamCity/run-server.ps1"]
 
-# In order to set system PATH, ContainerAdministrator must be used
+# Use ContainerAdministrator to update permissions and PATH
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd"
+# Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
+# ... F - full control, D - delete, /T - apply to subfolders & files
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r DefaultAccount:(OI)(CI)D /T
+RUN cmd /c icacls.exe C:\\TeamCity /grant:r Users:(OI)(CI)F /grant:r Users:(OI)(CI)D /T
+# Applied permission check for logging purposes
+RUN cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser


### PR DESCRIPTION
Pull request is dedicated to the update of Windows 2019-related Dockerfiles, handling the inability to download the files onto `C:/` folder with `ContainerAdministrator` user. Simmilar changes are already applied to Windows 2022-based Dockerfiles.

Such situation may occur within specific environments.