### PR TITLE
[TW-90511] Update plugins within Windows-based docker images

### DIFF
--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
@@ -34,7 +34,7 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 
 # Workaround for TW-87124 - Windows-based plugin directories receive incorrect case, causing their inability ...
 # ... to load. The directory will be fetched from the server upon the first update with proper case.
-RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
+#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
 
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
@@ -32,10 +32,6 @@ COPY TeamCity/buildAgent C:/BuildAgent
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Workaround for TW-87124 - Windows-based plugin directories receive incorrect case, causing their inability ...
-# ... to load. The directory will be fetched from the server upon the first update with proper case.
-#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
-
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -34,7 +34,7 @@ COPY TeamCity/buildAgent C:/BuildAgent
 
 # Workaround for TW-87124 - Windows 2022-based plugin directories receive incorrect case, causing their inability ...
 # ... to load. The directory will be fetched from the server upon the first update with proper case.
-RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
+#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
 
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -32,10 +32,6 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 RUN mkdir C:\\BuildAgent
 COPY TeamCity/buildAgent C:/BuildAgent
 
-# Workaround for TW-87124 - Windows 2022-based plugin directories receive incorrect case, causing their inability ...
-# ... to load. The directory will be fetched from the server upon the first update with proper case.
-#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
-
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK

--- a/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
@@ -28,7 +28,7 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 
 # Workaround for TW-87124 - Windows-based plugin directories receive incorrect case, causing their inability ...
 # ... to load. The directory will be fetched from the server upon the first update with proper case.
-RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
+#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
 
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 

--- a/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
@@ -26,10 +26,6 @@ COPY TeamCity/buildAgent C:/BuildAgent
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Workaround for TW-87124 - Windows-based plugin directories receive incorrect case, causing their inability ...
-# ... to load. The directory will be fetched from the server upon the first update with proper case.
-#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
-
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK

--- a/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
@@ -28,7 +28,7 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 
 # Workaround for TW-87124 - Windows-based plugin directories receive incorrect case, causing their inability ...
 # ... to load. The directory will be fetched from the server upon the first update with proper case.
-RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
+#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
 
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 

--- a/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
@@ -26,10 +26,6 @@ COPY TeamCity/buildAgent C:/BuildAgent
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Workaround for TW-87124 - Windows-based plugin directories receive incorrect case, causing their inability ...
-# ... to load. The directory will be fetched from the server upon the first update with proper case.
-#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
-
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK

--- a/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
@@ -28,7 +28,7 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 
 # Workaround for TW-87124 - Windows-based plugin directories receive incorrect case, causing their inability ...
 # ... to load. The directory will be fetched from the server upon the first update with proper case.
-RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
+#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
 
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 

--- a/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
@@ -26,10 +26,6 @@ COPY TeamCity/buildAgent C:/BuildAgent
 COPY scripts/*.cs /scripts/
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Workaround for TW-87124 - Windows-based plugin directories receive incorrect case, causing their inability ...
-# ... to load. The directory will be fetched from the server upon the first update with proper case.
-#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
-
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -28,7 +28,7 @@ COPY TeamCity/buildAgent C:/BuildAgent
 
 # Workaround for TW-87124 - Windows 2022-based plugin directories receive incorrect case, causing their inability ...
 # ... to load. The directory will be fetched from the server upon the first update with proper case.
-RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
+#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
 
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -26,10 +26,6 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 RUN mkdir C:\\BuildAgent
 COPY TeamCity/buildAgent C:/BuildAgent
 
-# Workaround for TW-87124 - Windows 2022-based plugin directories receive incorrect case, causing their inability ...
-# ... to load. The directory will be fetched from the server upon the first update with proper case.
-#RUN Remove-Item -Recurse -Force C:/BuildAgent/plugins
-
 COPY run-agent.ps1 /BuildAgent/run-agent.ps1
 
 # JDK

--- a/tool/agent-upgrade-dist/src/main/kotlin/Files.kt
+++ b/tool/agent-upgrade-dist/src/main/kotlin/Files.kt
@@ -2,30 +2,27 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
+import java.nio.file.Paths
 
 fun File.dir(): Sequence<File> = this.listFiles()?.asSequence() ?: emptySequence()
 
 fun File.ensureDirExists(description: String = "", createIfNotExists: Boolean = false): File {
-    if (this.isDirectory()) {
+    if (this.exists()) {
+        if (this.isDirectory) {
+            throw Exception("\"$this\" - is not a directory.");
+        }
+        return Paths.get(path).toRealPath().toFile()
+    }
+
+    if (createIfNotExists) {
+        this.mkdirs()
         if (description.isNotBlank()) {
             println("$description directory: ${this.canonicalFile}")
         }
-        return this.canonicalFile
+        return Paths.get(path).toRealPath().toFile()
     }
 
-    if (!this.exists()) {
-        if (createIfNotExists) {
-            this.mkdirs();
-            if (description.isNotBlank()) {
-                println("$description directory: ${this.canonicalFile}")
-            }
-            return this.canonicalFile
-        }
-
-        throw Exception("Cannot find directory \"$this\".");
-    }
-
-    throw Exception("\"$this\" - is not a directory.");
+    throw Exception("\"$this\" does not exist")
 }
 
 fun InputStream.buffered(bufferSize: Long): InputStream {


### PR DESCRIPTION
Pull request is dedicated to:
* The use of `RealPath `instead of the canonical path within the utility designed for generating zip archives for the image build, helping to preserve the case of file and directory names.
* Bundling of plugins back into Windows-based images. Previously, agent relied on the upgrade and plugins sent by the server.