### PR TITLE
TW-91535 Update Perforce Client within TeamCity Docker Images: 2022.2-2637361 -> 2022.2-2693782

### DIFF
--- a/configs/linux.config
+++ b/configs/linux.config
@@ -33,5 +33,5 @@ containerdIoLinuxComponentVersion=1.6.28-2
 
 # https://www.perforce.com/perforce-packages
 # https://package.perforce.com/apt/ubuntu/dists/focal/release/binary-amd64/Packages
-p4Version=2022.2-2637361
-p4Name=Perforce Helix Core client (p4) [2022.2-2637361](https://www.perforce.com/products/helix-core)
+p4Version=2022.2-2693782
+p4Name=Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -6,7 +6,7 @@ ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'
 ARG gitLFSLinuxComponentVersion='2.3.4-1'
 ARG gitLinuxComponentVersion='1:2.41.0-0ppa1~ubuntu18.04.1'
-ARG p4Version='2022.2-2637361'
+ARG p4Version='2022.2-2693782'
 ARG repo=''
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-18.04'
 

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -6,7 +6,7 @@ ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'
 ARG gitLFSLinuxComponentVersion='3.0.2-1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
-ARG p4Version='2022.2-2637361'
+ARG p4Version='2022.2-2693782'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -6,7 +6,7 @@ ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'
 ARG gitLFSLinuxComponentVersion='3.0.2-1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
-ARG p4Version='2022.2-2637361'
+ARG p4Version='2022.2-2693782'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -3,7 +3,7 @@ ARG gitLFSLinuxComponentVersion='2.3.4-1'
 ARG gitLinuxComponentVersion='1:2.41.0-0ppa1~ubuntu18.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='443750a02c28ff2807c80032ee2e8ebc'
-ARG p4Version='2022.2-2637361'
+ARG p4Version='2022.2-2693782'
 ARG repo=''
 ARG ubuntuImage='ubuntu:18.04'
 

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -3,7 +3,7 @@ ARG gitLFSLinuxComponentVersion='3.0.2-1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='443750a02c28ff2807c80032ee2e8ebc'
-ARG p4Version='2022.2-2637361'
+ARG p4Version='2022.2-2693782'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG ubuntuImage='ubuntu:20.04'
 

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -3,7 +3,7 @@ ARG gitLFSLinuxComponentVersion='3.0.2-1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='443750a02c28ff2807c80032ee2e8ebc'
-ARG p4Version='2022.2-2637361'
+ARG p4Version='2022.2-2693782'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG ubuntuImage='ubuntu:22.04'
 

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -104,7 +104,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2637361](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 
@@ -145,7 +145,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2637361](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 
@@ -341,7 +341,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2637361](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 
@@ -382,7 +382,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2637361](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 
@@ -561,7 +561,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2637361](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 
@@ -598,7 +598,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.6.0.413 (LTS) x86 Checksum (SHA512) ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2637361](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 

--- a/context/generated/teamcity-server.md
+++ b/context/generated/teamcity-server.md
@@ -71,7 +71,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) 443750a02c28ff2807c80032ee2e8ebc](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz)
 - Git v.2.47.1
 - Git LFS v.3.0.2-1
-- Perforce Helix Core client (p4) [2022.2-2637361](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 
@@ -101,7 +101,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) 443750a02c28ff2807c80032ee2e8ebc](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz)
 - Git v.2.47.1
 - Git LFS v.3.0.2-1
-- Perforce Helix Core client (p4) [2022.2-2637361](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 
@@ -186,7 +186,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.17.0.7.7.1 Checksum (MD5) 443750a02c28ff2807c80032ee2e8ebc](https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz)
 - Git v.2.41.0
 - Git LFS v.2.3.4
-- Perforce Helix Core client (p4) [2022.2-2637361](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
 
 Container platform: linux
 


### PR DESCRIPTION
Helix CLI Core 2022.2-2637361 had been removed from the public package registry.
```

28.77 E: Version '2022.2-2637361~jammy' for 'helix-cli-base' was not found

06:39:31   28.77 E: Version '2022.2-2637361~jammy' for 'helix-cli' was not found
```

The version referenced in the Dockerfiles should be updated accordingly.