### PR TITLE
[TW] Replace package-based Git installation with multistage build from sources to keep Git 2.47.1

### DIFF
--- a/configs/linux/Agent/Ubuntu/22.04/Ubuntu.Dockerfile.config
+++ b/configs/linux/Agent/Ubuntu/22.04/Ubuntu.Dockerfile.config
@@ -2,3 +2,4 @@ linuxVersion=
 repo=https://hub.docker.com/r/jetbrains/
 teamcityMinimalAgentImage=teamcity-minimal-agent:${versionTag}-linux
 dotnetLibs=libc6 libgcc1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g
+ubuntuImage=ubuntu:22.04

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -31,8 +31,53 @@
 # @AddToolToDoc ${p4Name}
 
 
+# Build runtime for Git & Git LFS binaries
+FROM ${teamcityMinimalAgentImage} AS builder
+
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
+RUN apt-get update && \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
 # Based on ${teamcityMinimalAgentImage}
 FROM ${teamcityMinimalAgentImage}
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+
 
 USER root
 
@@ -64,33 +109,9 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
-ENV GIT_LFS_VERSION=v3.4.1
-ENV GIT_VERSION=2.47.1
-
 RUN apt-get update && \
-    # Git dependencies
-    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev \
-      libexpat1-dev gettext unzip zlib1g-dev gnupg curl ca-certificates fontconfig locales && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-   # Git Installation
-       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-           tar -xvzf git-${GIT_VERSION}.tar.gz && \
-           cd git-${GIT_VERSION} && \
-           make configure && \
-           ./configure --prefix=/usr && \
-           make all && \
-           make install && \
-           cd .. && \
-           rm -rf git-${GIT_VERSION}* && \
-           git --version && \
-       # Git LFS Installation
-            curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-           mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-          cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
-           cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-# Perforce (p4 CLI)
+    # Perforce (p4 CLI)
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -32,7 +32,7 @@
 
 
 # Build runtime for Git & Git LFS binaries
-FROM ${teamcityMinimalAgentImage} AS builder
+FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
 ENV GIT_LFS_VERSION=v3.4.1

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -64,7 +64,7 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
-ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_LFS_VERSION=v3.4.1
 ENV GIT_VERSION=2.47.1
 
 RUN apt-get update && \

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -64,11 +64,30 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
+ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_VERSION=2.47.1
+
 RUN apt-get update && \
+    # Git dependencies
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev \
+      libexpat1-dev gettext unzip zlib1g-dev gnupg curl ca-certificates fontconfig locales && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
-    git lfs install --system && \
+   # Git Installation
+       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+           tar -xvzf git-${GIT_VERSION}.tar.gz && \
+           cd git-${GIT_VERSION} && \
+           make configure && \
+           ./configure --prefix=/usr && \
+           make all && \
+           make install && \
+           cd .. && \
+           rm -rf git-${GIT_VERSION}* && \
+           git --version && \
+       # Git LFS Installation
+            curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+           mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+          cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+           cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
 # Perforce (p4 CLI)

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -6,6 +6,7 @@
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
+# ARG ubuntuImage
 
 # Id teamcity-agent
 # Platform ${linuxPlatform}

--- a/configs/linux/Agent/UbuntuARM/22.04/UbuntuARM.Dockerfile.config
+++ b/configs/linux/Agent/UbuntuARM/22.04/UbuntuARM.Dockerfile.config
@@ -2,3 +2,4 @@ linuxVersion=-arm64
 repo=https://hub.docker.com/r/jetbrains/
 teamcityMinimalAgentImage=teamcity-minimal-agent:${versionTag}-linux${linuxVersion}
 dotnetLibs=libc6 libgcc1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g
+ubuntuImage=ubuntu:22.04

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -6,6 +6,7 @@
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
+# ARG ubuntuImage
 
 # Id teamcity-agent
 # Platform ${linuxPlatform}
@@ -28,8 +29,54 @@
 # @AddToolToDoc [${dotnetLinuxARM64ComponentName}](${dotnetLinuxARM64Component})
 
 
+
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
+
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
+RUN apt-get update && \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
 # Based on ${teamcityMinimalAgentImage}
 FROM ${teamcityMinimalAgentImage}
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+
 
 USER root
 
@@ -62,11 +109,6 @@ ARG containerdIoLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
-    git lfs install --system && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -108,12 +108,6 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
 
 EXPOSE 8111
 
-# Git
-ARG gitLinuxComponentVersion
-
-# Git LFS
-ARG gitLFSLinuxComponentVersion
-
 # Perforce installation
 ARG p4Version
 RUN apt-get update && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update && \
     ca-certificates \
     fontconfig \
     locales && \
+    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
@@ -89,6 +90,7 @@ ARG p4Version
 
 # Git Installation
 ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.0.2
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Git Installation
@@ -102,10 +104,11 @@ RUN apt-get update && \
         cd .. && \
         rm -rf git-${GIT_VERSION}* && \
         git --version && \
-    # Git LFS Installation
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
-    git lfs install --system && \
+           # Git LFS Installation
+                curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+               mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+              cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+               cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -95,14 +95,16 @@ RUN apt-get update && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
         tar -xvzf git-${GIT_VERSION}.tar.gz && \
         cd git-${GIT_VERSION} && \
-        make configure && ./configure --prefix=/usr && \
+        make configure && \
+        ./configure --prefix=/usr && \
         make all && \
         make install && \
         cd .. && \
         rm -rf git-${GIT_VERSION}* && \
+        git --version && \
     # Git LFS Installation
     add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} && \
+    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
     git lfs install --system && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -114,31 +114,10 @@ ARG gitLinuxComponentVersion
 # Git LFS
 ARG gitLFSLinuxComponentVersion
 
-# Perforce
+# Perforce installation
 ARG p4Version
-
-
-# Git Installation
-ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
-    # Git Installation
-    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-        tar -xvzf git-${GIT_VERSION}.tar.gz && \
-        cd git-${GIT_VERSION} && \
-        make configure && \
-        ./configure --prefix=/usr && \
-        make all && \
-        make install && \
-        cd .. && \
-        rm -rf git-${GIT_VERSION}* && \
-        git --version && \
-           # Git LFS Installation
-                curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-               mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-              cd git-lfs-${GIT_LFS_VERSION}  && ls && ./install.sh && \
-               cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -26,12 +26,25 @@ FROM ${ubuntuImage}
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
+    apt-get install -y --no-install-recommends \
+    libssl-dev \
+    build-essential \
+    autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl \
+    ca-certificates \
+    fontconfig \
+    locales && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    rm -rf /var/lib/apt/lists/*
+    locale-gen en_US.UTF-8
 
 # JDK preparation start
 ARG jdkServerLinuxComponent
@@ -73,10 +86,23 @@ ARG gitLFSLinuxComponentVersion
 # Perforce
 ARG p4Version
 
+
+# Git Installation
+ENV GIT_VERSION=2.47.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
+    # Git Installation
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+        tar -xvzf git-${GIT_VERSION}.tar.gz && \
+        cd git-${GIT_VERSION} && \
+        make configure && ./configure --prefix=/usr && \
+        make all && \
+        make install && \
+        cd .. && \
+        rm -rf git-${GIT_VERSION}* && \
+    # Git LFS Installation
     add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
+    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} && \
     git lfs install --system && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -90,7 +90,7 @@ ARG p4Version
 
 # Git Installation
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_LFS_VERSION=v3.4.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Git Installation
@@ -107,7 +107,7 @@ RUN apt-get update && \
            # Git LFS Installation
                 curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
                mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-              cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+              cd git-lfs-${GIT_LFS_VERSION}  && ls && ./install.sh && \
                cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -20,16 +20,16 @@
 # @AddToolToDoc ${gitLFSLinuxComponentName}
 # @AddToolToDoc ${p4Name}
 
-# Based on ${ubuntuImage} 0
-FROM ${ubuntuImage}
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
 
+# Install required dependencies for building Git and Git LFS
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libssl-dev \
-    build-essential \
-    autoconf \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
     make \
     gcc \
     libcurl4-openssl-dev \
@@ -38,14 +38,44 @@ RUN apt-get update && \
     unzip \
     zlib1g-dev \
     gnupg \
-    curl \
-    ca-certificates \
-    fontconfig \
-    locales && \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
+# Based on ${ubuntuImage} 0
+FROM ${ubuntuImage}
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip \
+    # Git & Git LFS Runtime dependencies
+    libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxComponent

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -25,12 +25,26 @@ FROM ${ubuntuImage}
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
+    apt-get install -y --no-install-recommends \
+    libssl-dev \
+    build-essential \
+    autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl \
+    ca-certificates \
+    fontconfig \
+    locales && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    rm -rf /var/lib/apt/lists/*
+    locale-gen en_US.UTF-8
 
 # JDK preparation start
 ARG jdkServerLinuxARM64Component
@@ -71,8 +85,20 @@ ARG gitLFSLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
+       # Git Installation
+       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+           tar -xvzf git-${GIT_VERSION}.tar.gz && \
+           cd git-${GIT_VERSION} && \
+           make configure && \
+           ./configure --prefix=/usr && \
+           make all && \
+           make install && \
+           cd .. && \
+           rm -rf git-${GIT_VERSION}* && \
+           git --version && \
+       # Git LFS Installation
+       add-apt-repository ppa:git-core/ppa -y && \
+       apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
     git lfs install --system && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -50,11 +50,11 @@ RUN apt-get update && \
     cd .. && \
     rm -rf git-${GIT_VERSION}* && \
     # Install Git LFS
-    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
     # Clean up
-    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -19,16 +19,17 @@
 # @AddToolToDoc ${gitLinuxComponentName}
 # @AddToolToDoc ${gitLFSLinuxComponentName}
 
-# Based on ${ubuntuImage} 0
-FROM ${ubuntuImage}
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
 
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libssl-dev \
-    build-essential \
-    autoconf \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
     make \
     gcc \
     libcurl4-openssl-dev \
@@ -37,10 +38,33 @@ RUN apt-get update && \
     unzip \
     zlib1g-dev \
     gnupg \
-    curl \
-    ca-certificates \
-    fontconfig \
-    locales && \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
+# Based on ${ubuntuImage} 0
+FROM ${ubuntuImage}
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
@@ -76,32 +100,6 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
     LANG=C.UTF-8
 
 EXPOSE 8111
-
-# Git
-ARG gitLinuxComponentVersion
-
-# Git LFS
-ARG gitLFSLinuxComponentVersion
-
-RUN apt-get update && \
-    apt-get install -y mercurial software-properties-common && \
-       # Git Installation
-       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-           tar -xvzf git-${GIT_VERSION}.tar.gz && \
-           cd git-${GIT_VERSION} && \
-           make configure && \
-           ./configure --prefix=/usr && \
-           make all && \
-           make install && \
-           cd .. && \
-           rm -rf git-${GIT_VERSION}* && \
-           git --version && \
-       # Git LFS Installation
-       add-apt-repository ppa:git-core/ppa -y && \
-       apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
-    git lfs install --system && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -18,6 +18,7 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-18.04'
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
+# ARG ubuntuImage
 
 
 

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -25,7 +25,7 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-18.04'
 
 
 # Build runtime for Git & Git LFS binaries
-FROM ${teamcityMinimalAgentImage} AS builder
+FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
 ENV GIT_LFS_VERSION=v3.4.1

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -56,7 +56,7 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
-ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_LFS_VERSION=v3.4.1
 ENV GIT_VERSION=2.47.1
 
 RUN apt-get update && \

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -24,7 +24,52 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-18.04'
 
 
 
+# Build runtime for Git & Git LFS binaries
+FROM ${teamcityMinimalAgentImage} AS builder
+
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
+RUN apt-get update && \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
 FROM ${teamcityMinimalAgentImage}
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+
 
 USER root
 
@@ -56,33 +101,9 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
-ENV GIT_LFS_VERSION=v3.4.1
-ENV GIT_VERSION=2.47.1
-
 RUN apt-get update && \
-    # Git dependencies
-    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev \
-      libexpat1-dev gettext unzip zlib1g-dev gnupg curl ca-certificates fontconfig locales && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-   # Git Installation
-       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-           tar -xvzf git-${GIT_VERSION}.tar.gz && \
-           cd git-${GIT_VERSION} && \
-           make configure && \
-           ./configure --prefix=/usr && \
-           make all && \
-           make install && \
-           cd .. && \
-           rm -rf git-${GIT_VERSION}* && \
-           git --version && \
-       # Git LFS Installation
-            curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-           mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-          cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
-           cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-# Perforce (p4 CLI)
+    # Perforce (p4 CLI)
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -56,11 +56,30 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
+ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_VERSION=2.47.1
+
 RUN apt-get update && \
+    # Git dependencies
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev \
+      libexpat1-dev gettext unzip zlib1g-dev gnupg curl ca-certificates fontconfig locales && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
-    git lfs install --system && \
+   # Git Installation
+       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+           tar -xvzf git-${GIT_VERSION}.tar.gz && \
+           cd git-${GIT_VERSION} && \
+           make configure && \
+           ./configure --prefix=/usr && \
+           make all && \
+           make install && \
+           cd .. && \
+           rm -rf git-${GIT_VERSION}* && \
+           git --version && \
+       # Git LFS Installation
+            curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+           mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+          cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+           cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
 # Perforce (p4 CLI)

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -24,7 +24,52 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 
 
 
+# Build runtime for Git & Git LFS binaries
+FROM ${teamcityMinimalAgentImage} AS builder
+
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
+RUN apt-get update && \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
 FROM ${teamcityMinimalAgentImage}
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+
 
 USER root
 
@@ -56,33 +101,9 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
-ENV GIT_LFS_VERSION=v3.4.1
-ENV GIT_VERSION=2.47.1
-
 RUN apt-get update && \
-    # Git dependencies
-    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev \
-      libexpat1-dev gettext unzip zlib1g-dev gnupg curl ca-certificates fontconfig locales && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-   # Git Installation
-       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-           tar -xvzf git-${GIT_VERSION}.tar.gz && \
-           cd git-${GIT_VERSION} && \
-           make configure && \
-           ./configure --prefix=/usr && \
-           make all && \
-           make install && \
-           cd .. && \
-           rm -rf git-${GIT_VERSION}* && \
-           git --version && \
-       # Git LFS Installation
-            curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-           mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-          cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
-           cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-# Perforce (p4 CLI)
+    # Perforce (p4 CLI)
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -56,7 +56,7 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
-ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_LFS_VERSION=v3.4.1
 ENV GIT_VERSION=2.47.1
 
 RUN apt-get update && \

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -18,6 +18,7 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
+# ARG ubuntuImage
 
 
 

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -56,11 +56,30 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
+ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_VERSION=2.47.1
+
 RUN apt-get update && \
+    # Git dependencies
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev \
+      libexpat1-dev gettext unzip zlib1g-dev gnupg curl ca-certificates fontconfig locales && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
-    git lfs install --system && \
+   # Git Installation
+       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+           tar -xvzf git-${GIT_VERSION}.tar.gz && \
+           cd git-${GIT_VERSION} && \
+           make configure && \
+           ./configure --prefix=/usr && \
+           make all && \
+           make install && \
+           cd .. && \
+           rm -rf git-${GIT_VERSION}* && \
+           git --version && \
+       # Git LFS Installation
+            curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+           mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+          cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+           cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
 # Perforce (p4 CLI)

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -25,7 +25,7 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 
 
 # Build runtime for Git & Git LFS binaries
-FROM ${teamcityMinimalAgentImage} AS builder
+FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
 ENV GIT_LFS_VERSION=v3.4.1

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -9,6 +9,7 @@ ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG p4Version='2022.2-2693782'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
+ARG ubuntuImage='ubuntu:22.04'
 
 # The list of required arguments
 # ARG dotnetLinuxComponent

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -24,7 +24,52 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 
 
 
+# Build runtime for Git & Git LFS binaries
+FROM ${teamcityMinimalAgentImage} AS builder
+
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
+RUN apt-get update && \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
 FROM ${teamcityMinimalAgentImage}
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+
 
 USER root
 
@@ -56,33 +101,9 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
-ENV GIT_LFS_VERSION=v3.4.1
-ENV GIT_VERSION=2.47.1
-
 RUN apt-get update && \
-    # Git dependencies
-    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev \
-      libexpat1-dev gettext unzip zlib1g-dev gnupg curl ca-certificates fontconfig locales && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-   # Git Installation
-       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-           tar -xvzf git-${GIT_VERSION}.tar.gz && \
-           cd git-${GIT_VERSION} && \
-           make configure && \
-           ./configure --prefix=/usr && \
-           make all && \
-           make install && \
-           cd .. && \
-           rm -rf git-${GIT_VERSION}* && \
-           git --version && \
-       # Git LFS Installation
-            curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-           mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-          cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
-           cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-# Perforce (p4 CLI)
+    # Perforce (p4 CLI)
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -56,7 +56,7 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
-ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_LFS_VERSION=v3.4.1
 ENV GIT_VERSION=2.47.1
 
 RUN apt-get update && \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -18,6 +18,7 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
+# ARG ubuntuImage
 
 
 

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -56,11 +56,30 @@ ARG dockerLinuxComponentVersion
 ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
+ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_VERSION=2.47.1
+
 RUN apt-get update && \
+    # Git dependencies
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev \
+      libexpat1-dev gettext unzip zlib1g-dev gnupg curl ca-certificates fontconfig locales && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
-    git lfs install --system && \
+   # Git Installation
+       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+           tar -xvzf git-${GIT_VERSION}.tar.gz && \
+           cd git-${GIT_VERSION} && \
+           make configure && \
+           ./configure --prefix=/usr && \
+           make all && \
+           make install && \
+           cd .. && \
+           rm -rf git-${GIT_VERSION}* && \
+           git --version && \
+       # Git LFS Installation
+            curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+           mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+          cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+           cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
 # Perforce (p4 CLI)

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -25,7 +25,7 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 
 
 # Build runtime for Git & Git LFS binaries
-FROM ${teamcityMinimalAgentImage} AS builder
+FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
 ENV GIT_LFS_VERSION=v3.4.1

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -17,13 +17,60 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64-18.04'
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
+# ARG ubuntuImage
 
 
 
 
+
+
+
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
+
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
+RUN apt-get update && \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
 
 
 FROM ${teamcityMinimalAgentImage}
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+
 
 USER root
 
@@ -56,11 +103,6 @@ ARG containerdIoLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
-    git lfs install --system && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -17,13 +17,60 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64'
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
+# ARG ubuntuImage
 
 
 
 
+
+
+
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
+
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
+RUN apt-get update && \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
 
 
 FROM ${teamcityMinimalAgentImage}
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+
 
 USER root
 
@@ -56,11 +103,6 @@ ARG containerdIoLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
-    git lfs install --system && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -8,6 +8,7 @@ ARG gitLFSLinuxComponentVersion='3.0.2-1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64'
+ARG ubuntuImage='ubuntu:22.04'
 
 # The list of required arguments
 # ARG dotnetLinuxARM64Component
@@ -17,13 +18,60 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64'
 # ARG gitLinuxComponentVersion
 # ARG gitLFSLinuxComponentVersion
 # ARG dockerLinuxComponentVersion
+# ARG ubuntuImage
 
 
 
 
+
+
+
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
+
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
+RUN apt-get update && \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
 
 
 FROM ${teamcityMinimalAgentImage}
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+
 
 USER root
 
@@ -56,11 +104,6 @@ ARG containerdIoLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
-    git lfs install --system && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -91,14 +91,16 @@ RUN apt-get update && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
         tar -xvzf git-${GIT_VERSION}.tar.gz && \
         cd git-${GIT_VERSION} && \
-        make configure && ./configure --prefix=/usr && \
+        make configure && \
+        ./configure --prefix=/usr && \
         make all && \
         make install && \
         cd .. && \
         rm -rf git-${GIT_VERSION}* && \
+        git --version && \
     # Git LFS Installation
     add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} && \
+    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
     git lfs install --system && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -85,7 +85,7 @@ ARG p4Version
 
 # Git Installation
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_LFS_VERSION=v3.4.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Git Installation
@@ -102,7 +102,7 @@ RUN apt-get update && \
            # Git LFS Installation
                 curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
                mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-              cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+              cd git-lfs-${GIT_LFS_VERSION}  && ls && ./install.sh && \
                cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -16,15 +16,16 @@ ARG ubuntuImage='ubuntu:18.04'
 
 
 
-FROM ${ubuntuImage}
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
 
+# Install required dependencies for building Git and Git LFS
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libssl-dev \
-    build-essential \
-    autoconf \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
     make \
     gcc \
     libcurl4-openssl-dev \
@@ -33,14 +34,43 @@ RUN apt-get update && \
     unzip \
     zlib1g-dev \
     gnupg \
-    curl \
-    ca-certificates \
-    fontconfig \
-    locales && \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
+FROM ${ubuntuImage}
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip \
+    # Git & Git LFS Runtime dependencies
+    libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxComponent

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -1,6 +1,4 @@
 # Default arguments
-ARG gitLFSLinuxComponentVersion='2.3.4-1'
-ARG gitLinuxComponentVersion='1:2.41.0-0ppa1~ubuntu18.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='443750a02c28ff2807c80032ee2e8ebc'
 ARG p4Version='2022.2-2693782'
@@ -102,12 +100,6 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
     LANG=C.UTF-8
 
 EXPOSE 8111
-
-# Git
-ARG gitLinuxComponentVersion
-
-# Git LFS
-ARG gitLFSLinuxComponentVersion
 
 # Perforce installation
 ARG p4Version

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -22,12 +22,25 @@ FROM ${ubuntuImage}
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
+    apt-get install -y --no-install-recommends \
+    libssl-dev \
+    build-essential \
+    autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl \
+    ca-certificates \
+    fontconfig \
+    locales && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    rm -rf /var/lib/apt/lists/*
+    locale-gen en_US.UTF-8
 
 # JDK preparation start
 ARG jdkServerLinuxComponent
@@ -69,10 +82,23 @@ ARG gitLFSLinuxComponentVersion
 # Perforce
 ARG p4Version
 
+
+# Git Installation
+ENV GIT_VERSION=2.47.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
+    # Git Installation
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+        tar -xvzf git-${GIT_VERSION}.tar.gz && \
+        cd git-${GIT_VERSION} && \
+        make configure && ./configure --prefix=/usr && \
+        make all && \
+        make install && \
+        cd .. && \
+        rm -rf git-${GIT_VERSION}* && \
+    # Git LFS Installation
     add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
+    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} && \
     git lfs install --system && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -109,31 +109,10 @@ ARG gitLinuxComponentVersion
 # Git LFS
 ARG gitLFSLinuxComponentVersion
 
-# Perforce
+# Perforce installation
 ARG p4Version
-
-
-# Git Installation
-ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
-    # Git Installation
-    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-        tar -xvzf git-${GIT_VERSION}.tar.gz && \
-        cd git-${GIT_VERSION} && \
-        make configure && \
-        ./configure --prefix=/usr && \
-        make all && \
-        make install && \
-        cd .. && \
-        rm -rf git-${GIT_VERSION}* && \
-        git --version && \
-           # Git LFS Installation
-                curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-               mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-              cd git-lfs-${GIT_LFS_VERSION}  && ls && ./install.sh && \
-               cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.41.0-0ppa1~ubuntu18.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='443750a02c28ff2807c80032ee2e8ebc'
 ARG p4Version='2022.2-2693782'
-ARG repo=''
 ARG ubuntuImage='ubuntu:18.04'
 
 # The list of required arguments
@@ -38,6 +37,7 @@ RUN apt-get update && \
     ca-certificates \
     fontconfig \
     locales && \
+    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
@@ -85,6 +85,7 @@ ARG p4Version
 
 # Git Installation
 ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.0.2
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Git Installation
@@ -98,10 +99,11 @@ RUN apt-get update && \
         cd .. && \
         rm -rf git-${GIT_VERSION}* && \
         git --version && \
-    # Git LFS Installation
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
-    git lfs install --system && \
+           # Git LFS Installation
+                curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+               mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+              cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+               cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -91,14 +91,16 @@ RUN apt-get update && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
         tar -xvzf git-${GIT_VERSION}.tar.gz && \
         cd git-${GIT_VERSION} && \
-        make configure && ./configure --prefix=/usr && \
+        make configure && \
+        ./configure --prefix=/usr && \
         make all && \
         make install && \
         cd .. && \
         rm -rf git-${GIT_VERSION}* && \
+        git --version && \
     # Git LFS Installation
     add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} && \
+    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
     git lfs install --system && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -85,7 +85,7 @@ ARG p4Version
 
 # Git Installation
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_LFS_VERSION=v3.4.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Git Installation
@@ -102,7 +102,7 @@ RUN apt-get update && \
            # Git LFS Installation
                 curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
                mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-              cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+              cd git-lfs-${GIT_LFS_VERSION}  && ls && ./install.sh && \
                cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -1,6 +1,4 @@
 # Default arguments
-ARG gitLFSLinuxComponentVersion='3.0.2-1'
-ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='443750a02c28ff2807c80032ee2e8ebc'
 ARG p4Version='2022.2-2693782'
@@ -102,12 +100,6 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
     LANG=C.UTF-8
 
 EXPOSE 8111
-
-# Git
-ARG gitLinuxComponentVersion
-
-# Git LFS
-ARG gitLFSLinuxComponentVersion
 
 # Perforce installation
 ARG p4Version

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -16,15 +16,16 @@ ARG ubuntuImage='ubuntu:20.04'
 
 
 
-FROM ${ubuntuImage}
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
 
+# Install required dependencies for building Git and Git LFS
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libssl-dev \
-    build-essential \
-    autoconf \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
     make \
     gcc \
     libcurl4-openssl-dev \
@@ -33,14 +34,43 @@ RUN apt-get update && \
     unzip \
     zlib1g-dev \
     gnupg \
-    curl \
-    ca-certificates \
-    fontconfig \
-    locales && \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
+FROM ${ubuntuImage}
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip \
+    # Git & Git LFS Runtime dependencies
+    libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxComponent

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='443750a02c28ff2807c80032ee2e8ebc'
 ARG p4Version='2022.2-2693782'
-ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG ubuntuImage='ubuntu:20.04'
 
 # The list of required arguments
@@ -38,6 +37,7 @@ RUN apt-get update && \
     ca-certificates \
     fontconfig \
     locales && \
+    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
@@ -85,6 +85,7 @@ ARG p4Version
 
 # Git Installation
 ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.0.2
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Git Installation
@@ -98,10 +99,11 @@ RUN apt-get update && \
         cd .. && \
         rm -rf git-${GIT_VERSION}* && \
         git --version && \
-    # Git LFS Installation
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
-    git lfs install --system && \
+           # Git LFS Installation
+                curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+               mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+              cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+               cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -22,12 +22,25 @@ FROM ${ubuntuImage}
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
+    apt-get install -y --no-install-recommends \
+    libssl-dev \
+    build-essential \
+    autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl \
+    ca-certificates \
+    fontconfig \
+    locales && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    rm -rf /var/lib/apt/lists/*
+    locale-gen en_US.UTF-8
 
 # JDK preparation start
 ARG jdkServerLinuxComponent
@@ -69,10 +82,23 @@ ARG gitLFSLinuxComponentVersion
 # Perforce
 ARG p4Version
 
+
+# Git Installation
+ENV GIT_VERSION=2.47.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
+    # Git Installation
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+        tar -xvzf git-${GIT_VERSION}.tar.gz && \
+        cd git-${GIT_VERSION} && \
+        make configure && ./configure --prefix=/usr && \
+        make all && \
+        make install && \
+        cd .. && \
+        rm -rf git-${GIT_VERSION}* && \
+    # Git LFS Installation
     add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
+    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} && \
     git lfs install --system && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -109,31 +109,10 @@ ARG gitLinuxComponentVersion
 # Git LFS
 ARG gitLFSLinuxComponentVersion
 
-# Perforce
+# Perforce installation
 ARG p4Version
-
-
-# Git Installation
-ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
-    # Git Installation
-    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-        tar -xvzf git-${GIT_VERSION}.tar.gz && \
-        cd git-${GIT_VERSION} && \
-        make configure && \
-        ./configure --prefix=/usr && \
-        make all && \
-        make install && \
-        cd .. && \
-        rm -rf git-${GIT_VERSION}* && \
-        git --version && \
-           # Git LFS Installation
-                curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-               mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-              cd git-lfs-${GIT_LFS_VERSION}  && ls && ./install.sh && \
-               cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -91,14 +91,16 @@ RUN apt-get update && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
         tar -xvzf git-${GIT_VERSION}.tar.gz && \
         cd git-${GIT_VERSION} && \
-        make configure && ./configure --prefix=/usr && \
+        make configure && \
+        ./configure --prefix=/usr && \
         make all && \
         make install && \
         cd .. && \
         rm -rf git-${GIT_VERSION}* && \
+        git --version && \
     # Git LFS Installation
     add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} && \
+    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
     git lfs install --system && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -85,7 +85,7 @@ ARG p4Version
 
 # Git Installation
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.0.2
+ENV GIT_LFS_VERSION=v3.4.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Git Installation
@@ -102,7 +102,7 @@ RUN apt-get update && \
            # Git LFS Installation
                 curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
                mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-              cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+              cd git-lfs-${GIT_LFS_VERSION}  && ls && ./install.sh && \
                cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -1,6 +1,4 @@
 # Default arguments
-ARG gitLFSLinuxComponentVersion='3.0.2-1'
-ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='443750a02c28ff2807c80032ee2e8ebc'
 ARG p4Version='2022.2-2693782'
@@ -102,12 +100,6 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
     LANG=C.UTF-8
 
 EXPOSE 8111
-
-# Git
-ARG gitLinuxComponentVersion
-
-# Git LFS
-ARG gitLFSLinuxComponentVersion
 
 # Perforce installation
 ARG p4Version

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='443750a02c28ff2807c80032ee2e8ebc'
 ARG p4Version='2022.2-2693782'
-ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG ubuntuImage='ubuntu:22.04'
 
 # The list of required arguments
@@ -38,6 +37,7 @@ RUN apt-get update && \
     ca-certificates \
     fontconfig \
     locales && \
+    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
@@ -85,6 +85,7 @@ ARG p4Version
 
 # Git Installation
 ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.0.2
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Git Installation
@@ -98,10 +99,11 @@ RUN apt-get update && \
         cd .. && \
         rm -rf git-${GIT_VERSION}* && \
         git --version && \
-    # Git LFS Installation
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
-    git lfs install --system && \
+           # Git LFS Installation
+                curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+               mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+              cd git-lfs-${GIT_LFS_VERSION}  && ./install.sh && \
+               cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -22,12 +22,25 @@ FROM ${ubuntuImage}
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
+    apt-get install -y --no-install-recommends \
+    libssl-dev \
+    build-essential \
+    autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl \
+    ca-certificates \
+    fontconfig \
+    locales && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    rm -rf /var/lib/apt/lists/*
+    locale-gen en_US.UTF-8
 
 # JDK preparation start
 ARG jdkServerLinuxComponent
@@ -69,10 +82,23 @@ ARG gitLFSLinuxComponentVersion
 # Perforce
 ARG p4Version
 
+
+# Git Installation
+ENV GIT_VERSION=2.47.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
+    # Git Installation
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+        tar -xvzf git-${GIT_VERSION}.tar.gz && \
+        cd git-${GIT_VERSION} && \
+        make configure && ./configure --prefix=/usr && \
+        make all && \
+        make install && \
+        cd .. && \
+        rm -rf git-${GIT_VERSION}* && \
+    # Git LFS Installation
     add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
+    apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} && \
     git lfs install --system && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -109,31 +109,10 @@ ARG gitLinuxComponentVersion
 # Git LFS
 ARG gitLFSLinuxComponentVersion
 
-# Perforce
+# Perforce installation
 ARG p4Version
-
-
-# Git Installation
-ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
-    # Git Installation
-    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-        tar -xvzf git-${GIT_VERSION}.tar.gz && \
-        cd git-${GIT_VERSION} && \
-        make configure && \
-        ./configure --prefix=/usr && \
-        make all && \
-        make install && \
-        cd .. && \
-        rm -rf git-${GIT_VERSION}* && \
-        git --version && \
-           # Git LFS Installation
-                curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-               mkdir git-lfs-${GIT_LFS_VERSION} &&  tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-              cd git-lfs-${GIT_LFS_VERSION}  && ls && ./install.sh && \
-               cd .. && rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
     (. /etc/os-release && \
       echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -16,15 +16,16 @@ ARG ubuntuImage='ubuntu:22.04'
 
 
 
-FROM ${ubuntuImage}
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
 
+# Install required dependencies for building Git and Git LFS
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libssl-dev \
-    build-essential \
-    autoconf \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
     make \
     gcc \
     libcurl4-openssl-dev \
@@ -33,14 +34,43 @@ RUN apt-get update && \
     unzip \
     zlib1g-dev \
     gnupg \
-    curl \
-    ca-certificates \
-    fontconfig \
-    locales && \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
+FROM ${ubuntuImage}
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip \
+    # Git & Git LFS Runtime dependencies
+    libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+
+# Copy compiled Git and Git LFS from the builder stage
+COPY --from=builder /usr/bin/git /usr/bin/git
+COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=builder /usr/share/git-core /usr/share/git-core
+COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxComponent

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -21,12 +21,26 @@ FROM ${ubuntuImage}
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
+    apt-get install -y --no-install-recommends \
+    libssl-dev \
+    build-essential \
+    autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl \
+    ca-certificates \
+    fontconfig \
+    locales && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    rm -rf /var/lib/apt/lists/*
+    locale-gen en_US.UTF-8
 
 # JDK preparation start
 ARG jdkServerLinuxARM64Component
@@ -67,8 +81,20 @@ ARG gitLFSLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
+       # Git Installation
+       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+           tar -xvzf git-${GIT_VERSION}.tar.gz && \
+           cd git-${GIT_VERSION} && \
+           make configure && \
+           ./configure --prefix=/usr && \
+           make all && \
+           make install && \
+           cd .. && \
+           rm -rf git-${GIT_VERSION}* && \
+           git --version && \
+       # Git LFS Installation
+       add-apt-repository ppa:git-core/ppa -y && \
+       apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
     git lfs install --system && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -44,11 +44,11 @@ RUN apt-get update && \
     cd .. && \
     rm -rf git-${GIT_VERSION}* && \
     # Install Git LFS
-    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
     # Clean up
-    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -1,9 +1,6 @@
 # Default arguments
-ARG gitLFSLinuxComponentVersion='2.3.4-1'
-ARG gitLinuxComponentVersion='1:2.41.0-0ppa1~ubuntu18.04.1'
 ARG jdkServerLinuxARM64Component='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-aarch64.tar.gz'
 ARG jdkServerLinuxARM64ComponentMD5SUM='c55e3d0615fac07f948ac3adaed818e9'
-ARG repo=''
 ARG ubuntuImage='ubuntu:18.04'
 
 # The list of required arguments
@@ -16,15 +13,17 @@ ARG ubuntuImage='ubuntu:18.04'
 
 
 
-FROM ${ubuntuImage}
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
 
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libssl-dev \
-    build-essential \
-    autoconf \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
     make \
     gcc \
     libcurl4-openssl-dev \
@@ -33,10 +32,32 @@ RUN apt-get update && \
     unzip \
     zlib1g-dev \
     gnupg \
-    curl \
-    ca-certificates \
-    fontconfig \
-    locales && \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
+FROM ${ubuntuImage}
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
@@ -72,32 +93,6 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
     LANG=C.UTF-8
 
 EXPOSE 8111
-
-# Git
-ARG gitLinuxComponentVersion
-
-# Git LFS
-ARG gitLFSLinuxComponentVersion
-
-RUN apt-get update && \
-    apt-get install -y mercurial software-properties-common && \
-       # Git Installation
-       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-           tar -xvzf git-${GIT_VERSION}.tar.gz && \
-           cd git-${GIT_VERSION} && \
-           make configure && \
-           ./configure --prefix=/usr && \
-           make all && \
-           make install && \
-           cd .. && \
-           rm -rf git-${GIT_VERSION}* && \
-           git --version && \
-       # Git LFS Installation
-       add-apt-repository ppa:git-core/ppa -y && \
-       apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
-    git lfs install --system && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -1,9 +1,6 @@
 # Default arguments
-ARG gitLFSLinuxComponentVersion='3.0.2-1'
-ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG jdkServerLinuxARM64Component='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-aarch64.tar.gz'
 ARG jdkServerLinuxARM64ComponentMD5SUM='c55e3d0615fac07f948ac3adaed818e9'
-ARG repo=''
 ARG ubuntuImage='ubuntu:20.04'
 
 # The list of required arguments
@@ -16,15 +13,17 @@ ARG ubuntuImage='ubuntu:20.04'
 
 
 
-FROM ${ubuntuImage}
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
 
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libssl-dev \
-    build-essential \
-    autoconf \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
     make \
     gcc \
     libcurl4-openssl-dev \
@@ -33,10 +32,32 @@ RUN apt-get update && \
     unzip \
     zlib1g-dev \
     gnupg \
-    curl \
-    ca-certificates \
-    fontconfig \
-    locales && \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
+FROM ${ubuntuImage}
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
@@ -72,32 +93,6 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
     LANG=C.UTF-8
 
 EXPOSE 8111
-
-# Git
-ARG gitLinuxComponentVersion
-
-# Git LFS
-ARG gitLFSLinuxComponentVersion
-
-RUN apt-get update && \
-    apt-get install -y mercurial software-properties-common && \
-       # Git Installation
-       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-           tar -xvzf git-${GIT_VERSION}.tar.gz && \
-           cd git-${GIT_VERSION} && \
-           make configure && \
-           ./configure --prefix=/usr && \
-           make all && \
-           make install && \
-           cd .. && \
-           rm -rf git-${GIT_VERSION}* && \
-           git --version && \
-       # Git LFS Installation
-       add-apt-repository ppa:git-core/ppa -y && \
-       apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
-    git lfs install --system && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -21,12 +21,26 @@ FROM ${ubuntuImage}
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
+    apt-get install -y --no-install-recommends \
+    libssl-dev \
+    build-essential \
+    autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl \
+    ca-certificates \
+    fontconfig \
+    locales && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    rm -rf /var/lib/apt/lists/*
+    locale-gen en_US.UTF-8
 
 # JDK preparation start
 ARG jdkServerLinuxARM64Component
@@ -67,8 +81,20 @@ ARG gitLFSLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
+       # Git Installation
+       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+           tar -xvzf git-${GIT_VERSION}.tar.gz && \
+           cd git-${GIT_VERSION} && \
+           make configure && \
+           ./configure --prefix=/usr && \
+           make all && \
+           make install && \
+           cd .. && \
+           rm -rf git-${GIT_VERSION}* && \
+           git --version && \
+       # Git LFS Installation
+       add-apt-repository ppa:git-core/ppa -y && \
+       apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
     git lfs install --system && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -44,11 +44,11 @@ RUN apt-get update && \
     cd .. && \
     rm -rf git-${GIT_VERSION}* && \
     # Install Git LFS
-    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
     # Clean up
-    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -1,9 +1,6 @@
 # Default arguments
-ARG gitLFSLinuxComponentVersion='3.0.2-1'
-ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG jdkServerLinuxARM64Component='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-aarch64.tar.gz'
 ARG jdkServerLinuxARM64ComponentMD5SUM='c55e3d0615fac07f948ac3adaed818e9'
-ARG repo=''
 ARG ubuntuImage='ubuntu:22.04'
 
 # The list of required arguments
@@ -16,15 +13,17 @@ ARG ubuntuImage='ubuntu:22.04'
 
 
 
-FROM ${ubuntuImage}
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+# Build runtime for Git & Git LFS binaries
+FROM ${ubuntuImage} AS builder
 
+ENV GIT_VERSION=2.47.1
+ENV GIT_LFS_VERSION=v3.4.1
+
+# Install required dependencies for building Git and Git LFS
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libssl-dev \
-    build-essential \
-    autoconf \
+    apt-get install -y \
+    libssl-dev build-essential autoconf \
     make \
     gcc \
     libcurl4-openssl-dev \
@@ -33,10 +32,32 @@ RUN apt-get update && \
     unzip \
     zlib1g-dev \
     gnupg \
-    curl \
-    ca-certificates \
-    fontconfig \
-    locales && \
+    curl && \
+    # Install Git
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+    curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
+    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    cd git-${GIT_VERSION} && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
+    make install && \
+    cd .. && \
+    rm -rf git-${GIT_VERSION}* && \
+    # Install Git LFS
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Clean up
+    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+
+FROM ${ubuntuImage}
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
@@ -72,32 +93,6 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
     LANG=C.UTF-8
 
 EXPOSE 8111
-
-# Git
-ARG gitLinuxComponentVersion
-
-# Git LFS
-ARG gitLFSLinuxComponentVersion
-
-RUN apt-get update && \
-    apt-get install -y mercurial software-properties-common && \
-       # Git Installation
-       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
-           tar -xvzf git-${GIT_VERSION}.tar.gz && \
-           cd git-${GIT_VERSION} && \
-           make configure && \
-           ./configure --prefix=/usr && \
-           make all && \
-           make install && \
-           cd .. && \
-           rm -rf git-${GIT_VERSION}* && \
-           git --version && \
-       # Git LFS Installation
-       add-apt-repository ppa:git-core/ppa -y && \
-       apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
-    git lfs install --system && \
-    # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -21,12 +21,26 @@ FROM ${ubuntuImage}
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
+    apt-get install -y --no-install-recommends \
+    libssl-dev \
+    build-essential \
+    autoconf \
+    make \
+    gcc \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    unzip \
+    zlib1g-dev \
+    gnupg \
+    curl \
+    ca-certificates \
+    fontconfig \
+    locales && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    rm -rf /var/lib/apt/lists/*
+    locale-gen en_US.UTF-8
 
 # JDK preparation start
 ARG jdkServerLinuxARM64Component
@@ -67,8 +81,20 @@ ARG gitLFSLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial software-properties-common && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
+       # Git Installation
+       curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
+           tar -xvzf git-${GIT_VERSION}.tar.gz && \
+           cd git-${GIT_VERSION} && \
+           make configure && \
+           ./configure --prefix=/usr && \
+           make all && \
+           make install && \
+           cd .. && \
+           rm -rf git-${GIT_VERSION}* && \
+           git --version && \
+       # Git LFS Installation
+       add-apt-repository ppa:git-core/ppa -y && \
+       apt-get install -y git-lfs=${gitLFSLinuxComponentVersion} git- && \
     git lfs install --system && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -44,11 +44,11 @@ RUN apt-get update && \
     cd .. && \
     rm -rf git-${GIT_VERSION}* && \
     # Install Git LFS
-    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
-    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
+    mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
     # Clean up
-    rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
+    rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
Recently, Git 2.47.1 had been removed from Git's PPA (git-core/ppa), replacing it with the newer 2.48.0 version.

Unfortunately, the newer version includes an issue related to the fetch of the tags with shadow clones ([details](https://lore.kernel.org/all/CAM6buW5KSDGHD7txroqVa0TN_Ou_eV-LocMy06cPy0ZGDQmY9A@mail.gmail.com/T/)), preventing us from bundling it into the image, as it may affect the behavior of build steps.



Due to the open-source nature of TeamCity Docker Images, any non-publicly accessible mirrors cannot be used. Therefore, package-based installation had been replaced with the compilation from sources.