### PR TITLE
[TW-91666] Docker Images: update Git LFS (3.0.2 -> 3.6.1)

### DIFF
--- a/configs/linux.config
+++ b/configs/linux.config
@@ -22,8 +22,8 @@ gitLinuxComponentVersion=1:2.47.1-0ppa1~ubuntu22.04.1
 gitLinuxComponentName=Git v.2.47.1
 
 # https://packages.ubuntu.com/focal/git-lfs
-gitLFSLinuxComponentVersion=3.0.2-1
-gitLFSLinuxComponentName=Git LFS v.3.0.2-1
+gitLFSLinuxComponentVersion=3.6.1
+gitLFSLinuxComponentName=Git LFS v.3.6.1
 
 dockerLinuxComponentVersion=5:27.3.1-1~ubuntu
 dockerLinuxComponentName=[Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -36,7 +36,7 @@
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -34,7 +34,7 @@
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -24,7 +24,7 @@
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -24,7 +24,7 @@
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -29,7 +29,7 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-18.04'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -4,7 +4,7 @@ ARG dockerLinuxComponentVersion='5:27.3.1-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'
-ARG gitLFSLinuxComponentVersion='3.0.2-1'
+ARG gitLFSLinuxComponentVersion='3.6.1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG p4Version='2022.2-2693782'
 ARG repo='https://hub.docker.com/r/jetbrains/'
@@ -29,7 +29,7 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -4,7 +4,7 @@ ARG dockerLinuxComponentVersion='5:27.3.1-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'
-ARG gitLFSLinuxComponentVersion='3.0.2-1'
+ARG gitLFSLinuxComponentVersion='3.6.1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG p4Version='2022.2-2693782'
 ARG repo='https://hub.docker.com/r/jetbrains/'
@@ -30,7 +30,7 @@ ARG ubuntuImage='ubuntu:22.04'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -29,7 +29,7 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64-18.04'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -4,7 +4,7 @@ ARG dockerLinuxComponentVersion='5:27.3.1-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759'
-ARG gitLFSLinuxComponentVersion='3.0.2-1'
+ARG gitLFSLinuxComponentVersion='3.6.1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64'
@@ -29,7 +29,7 @@ ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -4,7 +4,7 @@ ARG dockerLinuxComponentVersion='5:27.3.1-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='7f05a9774d79e694da5a6115d9916abf87a65e40bd6bdaa5dca1f705795436bc8e764242f7045207386a86732ef5519f60bdb516a3860e4860bca7ee91a21759'
-ARG gitLFSLinuxComponentVersion='3.0.2-1'
+ARG gitLFSLinuxComponentVersion='3.6.1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64'
@@ -30,7 +30,7 @@ ARG ubuntuImage='ubuntu:22.04'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -18,7 +18,7 @@ ARG ubuntuImage='ubuntu:18.04'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -18,7 +18,7 @@ ARG ubuntuImage='ubuntu:20.04'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -18,7 +18,7 @@ ARG ubuntuImage='ubuntu:22.04'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -18,7 +18,7 @@ ARG ubuntuImage='ubuntu:18.04'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -18,7 +18,7 @@ ARG ubuntuImage='ubuntu:20.04'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -18,7 +18,7 @@ ARG ubuntuImage='ubuntu:22.04'
 FROM ${ubuntuImage} AS builder
 
 ENV GIT_VERSION=2.47.1
-ENV GIT_LFS_VERSION=v3.4.1
+ENV GIT_LFS_VERSION=v3.6.1
 
 # Install required dependencies for building Git and Git LFS
 RUN apt-get update && \


### PR DESCRIPTION
Currently, TeamCity Docker images include Git LFS version 3.0.2 (included into the previous release), which is outdated. To incorporate the latest security fixes and features, we should update it to version 3.6.1.

