### PR TITLE
[TW-91776] Add the generation of the compiled locale data @ AMD images

### DIFF
--- a/configs/linux/MinimalAgent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/MinimalAgent/Ubuntu/Ubuntu.Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
     apt-get install -y python3-venv && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/configs/linux/MinimalAgent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/MinimalAgent/UbuntuARM/UbuntuARM.Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
 # Python
     apt-get install -y python3-venv && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -69,7 +69,9 @@ RUN apt-get update && \
     libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+    # Locale adjustment. See TW-91776
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    locale-gen en_US.UTF-8
 
 # Copy compiled Git and Git LFS from the builder stage
 COPY --from=builder /usr/bin/git /usr/bin/git

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -65,8 +65,11 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
+    # Git & Git LFS Runtime dependencies
+    libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 

--- a/context/generated/linux/MinimalAgent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/18.04/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     apt-get install -y python3-venv && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     apt-get install -y python3-venv && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/context/generated/linux/MinimalAgent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/22.04/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     apt-get install -y python3-venv && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/context/generated/linux/MinimalAgent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/18.04/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
 # Python
     apt-get install -y python3-venv && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/context/generated/linux/MinimalAgent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/20.04/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
 # Python
     apt-get install -y python3-venv && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/context/generated/linux/MinimalAgent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/22.04/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
 # Python
     apt-get install -y python3-venv && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -62,7 +62,9 @@ RUN apt-get update && \
     libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+    # Locale adjustment. See TW-91776
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    locale-gen en_US.UTF-8
 
 # Copy compiled Git and Git LFS from the builder stage
 COPY --from=builder /usr/bin/git /usr/bin/git

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -62,7 +62,9 @@ RUN apt-get update && \
     libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+    # Locale adjustment. See TW-91776
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    locale-gen en_US.UTF-8
 
 # Copy compiled Git and Git LFS from the builder stage
 COPY --from=builder /usr/bin/git /usr/bin/git

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -62,7 +62,9 @@ RUN apt-get update && \
     libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+    # Locale adjustment. See TW-91776
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    locale-gen en_US.UTF-8
 
 # Copy compiled Git and Git LFS from the builder stage
 COPY --from=builder /usr/bin/git /usr/bin/git

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -58,8 +58,11 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
+    # Git & Git LFS Runtime dependencies
+    libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -58,8 +58,11 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
+    # Git & Git LFS Runtime dependencies
+    libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -58,8 +58,11 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip  && \
+    # Git & Git LFS Runtime dependencies
+    libcurl4-openssl-dev libexpat1-dev zlib1g-dev && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Locale adjustment. See TW-91776
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 


### PR DESCRIPTION
The issue addresses a regression [TW-91776](https://youtrack.jetbrains.com/issue/TW-91776) (`2024.12.1`), caused by incorrect locale within the AMD-based server containers.