### PR TITLE
[TW] Perforce: update bundled client (2022.2 -> 2024.2), include an ARM bundling

### DIFF
--- a/configs/linux.config
+++ b/configs/linux.config
@@ -33,7 +33,6 @@ dockerLinuxComponentName=[Docker v.27.3.1](https://docs.docker.com/engine/releas
 containerdIoLinuxComponentName=[Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 containerdIoLinuxComponentVersion=1.6.28-2
 
-# https://www.perforce.com/perforce-packages
-# https://package.perforce.com/apt/ubuntu/dists/jammy/release/binary-amd64/Packages
-p4Version=2024.4-2724534
-p4Name=Perforce Helix Core client (p4) [2024.4-2724534](https://www.perforce.com/products/helix-core)
+# https://www.perforce.com/downloads/perforce
+p4Version=r24.2
+p4Name=Perforce Helix Core client (p4) [2024.2](https://www.perforce.com/downloads/perforce)

--- a/configs/linux.config
+++ b/configs/linux.config
@@ -34,6 +34,6 @@ containerdIoLinuxComponentName=[Containerd.io v1.6.28-2](https://github.com/cont
 containerdIoLinuxComponentVersion=1.6.28-2
 
 # https://www.perforce.com/perforce-packages
-# https://package.perforce.com/apt/ubuntu/dists/focal/release/binary-amd64/Packages
-p4Version=2022.2-2693782
-p4Name=Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
+# https://package.perforce.com/apt/ubuntu/dists/jammy/release/binary-amd64/Packages
+p4Version=2024.4-2724534
+p4Name=Perforce Helix Core client (p4) [2024.4-2724534](https://www.perforce.com/products/helix-core)

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -112,12 +112,8 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
     # Perforce (p4 CLI)
-    apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
-    (. /etc/os-release && \
-      echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \
-      /etc/apt/sources.list.d/perforce.list ) && \
-    apt-get update && \
-    (. /etc/os-release && apt-get install -y helix-cli-base="${p4Version}~$VERSION_CODENAME" helix-cli="${p4Version}~$VERSION_CODENAME" ) && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     # Docker & ContainerD
@@ -148,7 +144,7 @@ RUN apt-get update && \
 # Trigger .NET CLI first run experience by running arbitrary cmd to populate local package cache
     dotnet help && \
     dotnet --info && \
-# Other
+# Other \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -112,7 +112,7 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -120,6 +120,9 @@ RUN apt-get update && \
       systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
+# Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -121,7 +121,7 @@ RUN apt-get update && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
 # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -116,12 +116,9 @@ EXPOSE 8111
 ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
-    apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
-    (. /etc/os-release && \
-      echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \
-      /etc/apt/sources.list.d/perforce.list ) && \
-    apt-get update && \
-    (. /etc/os-release && apt-get install -y helix-cli-base="${p4Version}~$VERSION_CODENAME" helix-cli="${p4Version}~$VERSION_CODENAME" ) && \
+    # Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -117,7 +117,7 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -112,9 +112,12 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
 
 EXPOSE 8111
 
-# SCM Operations: Mercirual & Mandatory utilities. Perforce Client is not available for ARM64.
+# SCM Operations: Mercirual, Perforce CLI & Mandatory utilities
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
+    # Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -116,7 +116,7 @@ EXPOSE 8111
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -6,7 +6,7 @@ ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406
 ARG dotnetLinuxComponentSHA512='d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a'
 ARG gitLFSLinuxComponentVersion='2.3.4-1'
 ARG gitLinuxComponentVersion='1:2.41.0-0ppa1~ubuntu18.04.1'
-ARG p4Version='2024.4-2724534'
+ARG p4Version='r24.2'
 ARG repo=''
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-18.04'
 
@@ -104,7 +104,7 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -6,7 +6,7 @@ ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406
 ARG dotnetLinuxComponentSHA512='d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a'
 ARG gitLFSLinuxComponentVersion='2.3.4-1'
 ARG gitLinuxComponentVersion='1:2.41.0-0ppa1~ubuntu18.04.1'
-ARG p4Version='2022.2-2693782'
+ARG p4Version='2024.4-2724534'
 ARG repo=''
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-18.04'
 
@@ -104,12 +104,8 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
     # Perforce (p4 CLI)
-    apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
-    (. /etc/os-release && \
-      echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \
-      /etc/apt/sources.list.d/perforce.list ) && \
-    apt-get update && \
-    (. /etc/os-release && apt-get install -y helix-cli-base="${p4Version}~$VERSION_CODENAME" helix-cli="${p4Version}~$VERSION_CODENAME" ) && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     # Docker & ContainerD
@@ -140,7 +136,7 @@ RUN apt-get update && \
 # Trigger .NET CLI first run experience by running arbitrary cmd to populate local package cache
     dotnet help && \
     dotnet --info && \
-# Other
+# Other \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -6,7 +6,7 @@ ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406
 ARG dotnetLinuxComponentSHA512='d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a'
 ARG gitLFSLinuxComponentVersion='3.6.1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
-ARG p4Version='2022.2-2693782'
+ARG p4Version='2024.4-2724534'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 
@@ -104,12 +104,8 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
     # Perforce (p4 CLI)
-    apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
-    (. /etc/os-release && \
-      echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \
-      /etc/apt/sources.list.d/perforce.list ) && \
-    apt-get update && \
-    (. /etc/os-release && apt-get install -y helix-cli-base="${p4Version}~$VERSION_CODENAME" helix-cli="${p4Version}~$VERSION_CODENAME" ) && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     # Docker & ContainerD
@@ -140,7 +136,7 @@ RUN apt-get update && \
 # Trigger .NET CLI first run experience by running arbitrary cmd to populate local package cache
     dotnet help && \
     dotnet --info && \
-# Other
+# Other \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -6,7 +6,7 @@ ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406
 ARG dotnetLinuxComponentSHA512='d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a'
 ARG gitLFSLinuxComponentVersion='3.6.1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
-ARG p4Version='2024.4-2724534'
+ARG p4Version='r24.2'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 
@@ -104,7 +104,7 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -6,7 +6,7 @@ ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406
 ARG dotnetLinuxComponentSHA512='d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a'
 ARG gitLFSLinuxComponentVersion='3.6.1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
-ARG p4Version='2024.4-2724534'
+ARG p4Version='r24.2'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 ARG ubuntuImage='ubuntu:22.04'
@@ -105,7 +105,7 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -6,7 +6,7 @@ ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406
 ARG dotnetLinuxComponentSHA512='d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a'
 ARG gitLFSLinuxComponentVersion='3.6.1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
-ARG p4Version='2022.2-2693782'
+ARG p4Version='2024.4-2724534'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
 ARG ubuntuImage='ubuntu:22.04'
@@ -105,12 +105,8 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https software-properties-common && \
     # Perforce (p4 CLI)
-    apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
-    (. /etc/os-release && \
-      echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \
-      /etc/apt/sources.list.d/perforce.list ) && \
-    apt-get update && \
-    (. /etc/os-release && apt-get install -y helix-cli-base="${p4Version}~$VERSION_CODENAME" helix-cli="${p4Version}~$VERSION_CODENAME" ) && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     # Docker & ContainerD
@@ -141,7 +137,7 @@ RUN apt-get update && \
 # Trigger .NET CLI first run experience by running arbitrary cmd to populate local package cache
     dotnet help && \
     dotnet --info && \
-# Other
+# Other \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -114,6 +114,9 @@ RUN apt-get update && \
       systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
+# Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -6,6 +6,7 @@ ARG dotnetLinuxARM64Component='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.
 ARG dotnetLinuxARM64ComponentSHA512='9b939f09fbda8a080b1266914ca02c4d60a95e85fa6a1344c378d394697de6935eb7d941dd9a3aeb977ada3aab561c614a5fe9b973824899cb02aa74e9c09988'
 ARG gitLFSLinuxComponentVersion='2.3.4-1'
 ARG gitLinuxComponentVersion='1:2.41.0-0ppa1~ubuntu18.04.1'
+ARG p4Version='r24.2'
 ARG repo=''
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64-18.04'
 
@@ -115,7 +116,7 @@ RUN apt-get update && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
 # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -114,6 +114,9 @@ RUN apt-get update && \
       systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
+# Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -6,6 +6,7 @@ ARG dotnetLinuxARM64Component='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.
 ARG dotnetLinuxARM64ComponentSHA512='9b939f09fbda8a080b1266914ca02c4d60a95e85fa6a1344c378d394697de6935eb7d941dd9a3aeb977ada3aab561c614a5fe9b973824899cb02aa74e9c09988'
 ARG gitLFSLinuxComponentVersion='3.6.1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
+ARG p4Version='r24.2'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64'
 
@@ -115,7 +116,7 @@ RUN apt-get update && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
 # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -115,6 +115,9 @@ RUN apt-get update && \
       systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
+# Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -6,6 +6,7 @@ ARG dotnetLinuxARM64Component='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.
 ARG dotnetLinuxARM64ComponentSHA512='9b939f09fbda8a080b1266914ca02c4d60a95e85fa6a1344c378d394697de6935eb7d941dd9a3aeb977ada3aab561c614a5fe9b973824899cb02aa74e9c09988'
 ARG gitLFSLinuxComponentVersion='3.6.1'
 ARG gitLinuxComponentVersion='1:2.47.1-0ppa1~ubuntu22.04.1'
+ARG p4Version='r24.2'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux-arm64'
 ARG ubuntuImage='ubuntu:22.04'
@@ -116,7 +117,7 @@ RUN apt-get update && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \
 # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
 # .NET Libraries
     apt-get install -y --no-install-recommends ${dotnetLibs} && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='49cefdfc07e785430013f8dfd24a3fd7'
-ARG p4Version='2022.2-2693782'
+ARG p4Version='2024.4-2724534'
 ARG ubuntuImage='ubuntu:18.04'
 
 # The list of required arguments
@@ -109,12 +109,9 @@ EXPOSE 8111
 ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
-    apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
-    (. /etc/os-release && \
-      echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \
-      /etc/apt/sources.list.d/perforce.list ) && \
-    apt-get update && \
-    (. /etc/os-release && apt-get install -y helix-cli-base="${p4Version}~$VERSION_CODENAME" helix-cli="${p4Version}~$VERSION_CODENAME" ) && \
+    # Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='49cefdfc07e785430013f8dfd24a3fd7'
-ARG p4Version='2024.4-2724534'
+ARG p4Version='r24.2'
 ARG ubuntuImage='ubuntu:18.04'
 
 # The list of required arguments
@@ -110,7 +110,7 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='49cefdfc07e785430013f8dfd24a3fd7'
-ARG p4Version='2024.4-2724534'
+ARG p4Version='r24.2'
 ARG ubuntuImage='ubuntu:20.04'
 
 # The list of required arguments
@@ -110,7 +110,7 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='49cefdfc07e785430013f8dfd24a3fd7'
-ARG p4Version='2022.2-2693782'
+ARG p4Version='2024.4-2724534'
 ARG ubuntuImage='ubuntu:20.04'
 
 # The list of required arguments
@@ -109,12 +109,9 @@ EXPOSE 8111
 ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
-    apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
-    (. /etc/os-release && \
-      echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \
-      /etc/apt/sources.list.d/perforce.list ) && \
-    apt-get update && \
-    (. /etc/os-release && apt-get install -y helix-cli-base="${p4Version}~$VERSION_CODENAME" helix-cli="${p4Version}~$VERSION_CODENAME" ) && \
+    # Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='49cefdfc07e785430013f8dfd24a3fd7'
-ARG p4Version='2022.2-2693782'
+ARG p4Version='2024.4-2724534'
 ARG ubuntuImage='ubuntu:22.04'
 
 # The list of required arguments
@@ -109,12 +109,9 @@ EXPOSE 8111
 ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
-    apt-key adv --fetch-keys https://package.perforce.com/perforce.pubkey && \
-    (. /etc/os-release && \
-      echo "deb http://package.perforce.com/apt/$ID $VERSION_CODENAME release" > \
-      /etc/apt/sources.list.d/perforce.list ) && \
-    apt-get update && \
-    (. /etc/os-release && apt-get install -y helix-cli-base="${p4Version}~$VERSION_CODENAME" helix-cli="${p4Version}~$VERSION_CODENAME" ) && \
+    # Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='49cefdfc07e785430013f8dfd24a3fd7'
-ARG p4Version='2024.4-2724534'
+ARG p4Version='r24.2'
 ARG ubuntuImage='ubuntu:22.04'
 
 # The list of required arguments
@@ -110,7 +110,7 @@ ARG p4Version
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26x86_64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -105,9 +105,12 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
 
 EXPOSE 8111
 
-# SCM Operations: Mercirual & Mandatory utilities. Perforce Client is not available for ARM64.
+# SCM Operations: Mercirual, Perforce CLI & Mandatory utilities
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
+    # Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -1,6 +1,7 @@
 # Default arguments
 ARG jdkServerLinuxARM64Component='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-aarch64.tar.gz'
 ARG jdkServerLinuxARM64ComponentMD5SUM='14e42338d8e0b52a69edaede9892ec23'
+ARG p4Version='r24.2'
 ARG ubuntuImage='ubuntu:18.04'
 
 # The list of required arguments
@@ -109,7 +110,7 @@ EXPOSE 8111
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -1,6 +1,7 @@
 # Default arguments
 ARG jdkServerLinuxARM64Component='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-aarch64.tar.gz'
 ARG jdkServerLinuxARM64ComponentMD5SUM='14e42338d8e0b52a69edaede9892ec23'
+ARG p4Version='r24.2'
 ARG ubuntuImage='ubuntu:20.04'
 
 # The list of required arguments
@@ -109,7 +110,7 @@ EXPOSE 8111
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -105,9 +105,12 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
 
 EXPOSE 8111
 
-# SCM Operations: Mercirual & Mandatory utilities. Perforce Client is not available for ARM64.
+# SCM Operations: Mercirual, Perforce CLI & Mandatory utilities
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
+    # Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -105,9 +105,12 @@ ENV TEAMCITY_DATA_PATH=/data/teamcity_server/datadir \
 
 EXPOSE 8111
 
-# SCM Operations: Mercirual & Mandatory utilities. Perforce Client is not available for ARM64.
+# SCM Operations: Mercirual, Perforce CLI & Mandatory utilities
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
+    # Perforce (p4 CLI)
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -1,6 +1,7 @@
 # Default arguments
 ARG jdkServerLinuxARM64Component='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-aarch64.tar.gz'
 ARG jdkServerLinuxARM64ComponentMD5SUM='14e42338d8e0b52a69edaede9892ec23'
+ARG p4Version='r24.2'
 ARG ubuntuImage='ubuntu:22.04'
 
 # The list of required arguments
@@ -109,7 +110,7 @@ EXPOSE 8111
 RUN apt-get update && \
     apt-get install -y mercurial gnupg software-properties-common && \
     # Perforce (p4 CLI)
-    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/r24.2/bin.linux26aarch64/p4" && \
+    curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -104,7 +104,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2024.2](https://www.perforce.com/downloads/perforce)
 
 Container platform: linux
 
@@ -145,7 +145,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2024.2](https://www.perforce.com/downloads/perforce)
 
 Container platform: linux
 
@@ -341,7 +341,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2024.2](https://www.perforce.com/downloads/perforce)
 
 Container platform: linux
 
@@ -382,7 +382,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2024.2](https://www.perforce.com/downloads/perforce)
 
 Container platform: linux
 
@@ -561,7 +561,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2024.2](https://www.perforce.com/downloads/perforce)
 
 Container platform: linux
 
@@ -598,7 +598,7 @@ Installed components:
 - [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
-- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2024.2](https://www.perforce.com/downloads/perforce)
 
 Container platform: linux
 

--- a/context/generated/teamcity-server.md
+++ b/context/generated/teamcity-server.md
@@ -71,7 +71,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.21.0.6.7.1 Checksum (MD5) 49cefdfc07e785430013f8dfd24a3fd7](https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz)
 - Git v.2.47.1
 - Git LFS v.3.6.1
-- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2024.2](https://www.perforce.com/downloads/perforce)
 
 Container platform: linux
 
@@ -101,7 +101,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.21.0.6.7.1 Checksum (MD5) 49cefdfc07e785430013f8dfd24a3fd7](https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz)
 - Git v.2.47.1
 - Git LFS v.3.6.1
-- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2024.2](https://www.perforce.com/downloads/perforce)
 
 Container platform: linux
 
@@ -186,7 +186,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.21.0.6.7.1 Checksum (MD5) 49cefdfc07e785430013f8dfd24a3fd7](https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz)
 - Git v.2.41.0
 - Git LFS v.2.3.4
-- Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
+- Perforce Helix Core client (p4) [2024.2](https://www.perforce.com/downloads/perforce)
 
 Container platform: linux
 


### PR DESCRIPTION
Pull request is dedicated to:
* an update of Perforce client (`p4`) bundled into TeamCity Docker Images;
* bundling of a `p4` binary into ARM-based TeamCity Agents;
* a related changes in the installation method;