### PR TITLE
[TW] Docker: update bundled version within Linux-based Docker images: 27.3.1 -> 27.5.1

### DIFF
--- a/configs/linux.config
+++ b/configs/linux.config
@@ -27,8 +27,8 @@ gitLinuxComponentName=Git v.2.47.1
 gitLFSLinuxComponentVersion=3.6.1
 gitLFSLinuxComponentName=Git LFS v.3.6.1
 
-dockerLinuxComponentVersion=5:27.3.1-1~ubuntu
-dockerLinuxComponentName=[Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+dockerLinuxComponentVersion=5:27.5.1-1~ubuntu
+dockerLinuxComponentName=[Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 
 containerdIoLinuxComponentName=[Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 containerdIoLinuxComponentVersion=1.6.28-2

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
-ARG dockerLinuxComponentVersion='5:27.3.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:27.5.1-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a'

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
-ARG dockerLinuxComponentVersion='5:27.3.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:27.5.1-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a'

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
-ARG dockerLinuxComponentVersion='5:27.3.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:27.5.1-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a'

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -101,7 +101,7 @@ Installed components:
 - Git LFS v.3.6.1
 - Git v.2.47.1
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
@@ -142,7 +142,7 @@ Installed components:
 - Git LFS v.3.6.1
 - Git v.2.47.1
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
@@ -181,7 +181,7 @@ Installed components:
 - Git v.2.47.1
 - Git LFS v.3.6.1
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) ARM64 Checksum (SHA512) 9b939f09fbda8a080b1266914ca02c4d60a95e85fa6a1344c378d394697de6935eb7d941dd9a3aeb977ada3aab561c614a5fe9b973824899cb02aa74e9c09988](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-arm64.tar.gz)
 
@@ -219,7 +219,7 @@ Installed components:
 - Git v.2.47.1
 - Git LFS v.3.6.1
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) ARM64 Checksum (SHA512) 9b939f09fbda8a080b1266914ca02c4d60a95e85fa6a1344c378d394697de6935eb7d941dd9a3aeb977ada3aab561c614a5fe9b973824899cb02aa74e9c09988](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-arm64.tar.gz)
 
@@ -258,7 +258,7 @@ Installed components:
 - Git v.2.47.1
 - Git LFS v.3.6.1
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) ARM64 Checksum (SHA512) 9b939f09fbda8a080b1266914ca02c4d60a95e85fa6a1344c378d394697de6935eb7d941dd9a3aeb977ada3aab561c614a5fe9b973824899cb02aa74e9c09988](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-arm64.tar.gz)
 
@@ -298,7 +298,7 @@ Installed components:
 - Git v.2.47.1
 - Git LFS v.3.6.1
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) ARM64 Checksum (SHA512) 9b939f09fbda8a080b1266914ca02c4d60a95e85fa6a1344c378d394697de6935eb7d941dd9a3aeb977ada3aab561c614a5fe9b973824899cb02aa74e9c09988](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-arm64.tar.gz)
 
@@ -338,7 +338,7 @@ Installed components:
 - Git LFS v.3.6.1
 - Git v.2.47.1
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
@@ -379,7 +379,7 @@ Installed components:
 - Git LFS v.3.6.1
 - Git v.2.47.1
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
@@ -558,7 +558,7 @@ Installed components:
 - Git LFS v.2.3.4
 - Git v.2.41.0
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
@@ -595,7 +595,7 @@ Installed components:
 - Git LFS v.3.6.1
 - Git v.2.47.1
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) x86 Checksum (SHA512) d6fdcfebd0df46959f7857cfb3beac7de6c8843515ece28b24802765fd9cfb6c7e9701b320134cb4907322937ab89cae914ddc21bf48b9b6313e9a9af5c1f24a](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-x64.tar.gz)
 - Perforce Helix Core client (p4) [2022.2-2693782](https://www.perforce.com/products/helix-core)
@@ -632,7 +632,7 @@ Installed components:
 - Git v.2.41.0
 - Git LFS v.2.3.4
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) ARM64 Checksum (SHA512) 9b939f09fbda8a080b1266914ca02c4d60a95e85fa6a1344c378d394697de6935eb7d941dd9a3aeb977ada3aab561c614a5fe9b973824899cb02aa74e9c09988](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-arm64.tar.gz)
 
@@ -668,7 +668,7 @@ Installed components:
 - Git v.2.47.1
 - Git LFS v.3.6.1
 - Mercurial
-- [Docker v.27.3.1](https://docs.docker.com/engine/release-notes/27)
+- [Docker v.27.5.1](https://docs.docker.com/engine/release-notes/27)
 - [Containerd.io v1.6.28-2](https://github.com/containerd/containerd/releases/tag/v1.6.28)
 - [.NET SDK v.8.0.406 (LTS) ARM64 Checksum (SHA512) 9b939f09fbda8a080b1266914ca02c4d60a95e85fa6a1344c378d394697de6935eb7d941dd9a3aeb977ada3aab561c614a5fe9b973824899cb02aa74e9c09988](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-linux-arm64.tar.gz)
 


### PR DESCRIPTION
Pull request is dedicated to the update of Docker within TeamCity Docker images.
See: [Docker Engine 27.5.1 release notes](https://docs.docker.com/engine/release-notes/27/#2751) 