### PR TITLE
[TW-92715] Git does not load large files when working with an LFS-enabled repository

### DIFF
--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -65,6 +65,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -73,7 +75,8 @@ RUN apt-get update && \
 # Based on ${teamcityMinimalAgentImage}
 FROM ${teamcityMinimalAgentImage}
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -64,9 +64,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -80,7 +80,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 USER root
 
@@ -147,10 +147,11 @@ RUN apt-get update && \
 # Trigger .NET CLI first run experience by running arbitrary cmd to populate local package cache
     dotnet help && \
     dotnet --info && \
-# Other \
+# Other
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
-    usermod -aG docker buildagent
+    usermod -aG docker buildagent && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -151,7 +151,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -62,8 +62,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    sed -i 's/git lfs install/git lfs install --system/' git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -77,7 +78,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 USER root
 

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -62,9 +62,8 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    sed -i 's/git lfs install/git lfs install --system/' git-lfs-${GIT_LFS_VERSION}/install.sh && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -63,6 +63,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -71,7 +73,8 @@ RUN apt-get update && \
 # Based on ${teamcityMinimalAgentImage}
 FROM ${teamcityMinimalAgentImage}
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -145,7 +145,8 @@ RUN apt-get update && \
 # Other
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
-    usermod -aG docker buildagent
+    usermod -aG docker buildagent && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -146,7 +146,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -53,6 +53,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -75,7 +77,8 @@ RUN apt-get update && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -52,9 +52,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -82,7 +82,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxComponent
@@ -123,7 +123,9 @@ RUN apt-get update && \
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -124,7 +124,7 @@ RUN apt-get update && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 
 COPY welcome.sh /welcome.sh

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -123,7 +123,7 @@ RUN apt-get update && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -53,6 +53,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -75,7 +77,8 @@ RUN apt-get update && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -122,7 +122,8 @@ RUN apt-get update && \
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -53,8 +53,6 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -82,7 +82,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxARM64Component

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -52,7 +52,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -57,9 +57,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -72,7 +72,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 USER root
 
@@ -139,10 +139,11 @@ RUN apt-get update && \
 # Trigger .NET CLI first run experience by running arbitrary cmd to populate local package cache
     dotnet help && \
     dotnet --info && \
-# Other \
+# Other
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
-    usermod -aG docker buildagent
+    usermod -aG docker buildagent && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -58,6 +58,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -65,7 +67,8 @@ RUN apt-get update && \
 
 FROM ${teamcityMinimalAgentImage}
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -143,7 +143,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -57,9 +57,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -72,7 +72,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 USER root
 
@@ -139,10 +139,11 @@ RUN apt-get update && \
 # Trigger .NET CLI first run experience by running arbitrary cmd to populate local package cache
     dotnet help && \
     dotnet --info && \
-# Other \
+# Other
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
-    usermod -aG docker buildagent
+    usermod -aG docker buildagent && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -58,6 +58,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -65,7 +67,8 @@ RUN apt-get update && \
 
 FROM ${teamcityMinimalAgentImage}
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -143,7 +143,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -144,7 +144,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -58,9 +58,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -73,7 +73,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 USER root
 
@@ -140,10 +140,11 @@ RUN apt-get update && \
 # Trigger .NET CLI first run experience by running arbitrary cmd to populate local package cache
     dotnet help && \
     dotnet --info && \
-# Other \
+# Other
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
-    usermod -aG docker buildagent
+    usermod -aG docker buildagent && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -59,6 +59,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -66,7 +68,8 @@ RUN apt-get update && \
 
 FROM ${teamcityMinimalAgentImage}
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -141,7 +141,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -140,7 +140,8 @@ RUN apt-get update && \
 # Other
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
-    usermod -aG docker buildagent
+    usermod -aG docker buildagent && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -59,6 +59,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -66,7 +68,8 @@ RUN apt-get update && \
 
 FROM ${teamcityMinimalAgentImage}
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -58,9 +58,8 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    sed -i 's/git lfs install/git lfs install --system/' git-lfs-${GIT_LFS_VERSION}/install.sh && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -58,8 +58,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    sed -i 's/git lfs install/git lfs install --system/' git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -72,7 +73,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 USER root
 

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -141,7 +141,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -140,7 +140,8 @@ RUN apt-get update && \
 # Other
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
-    usermod -aG docker buildagent
+    usermod -aG docker buildagent && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -59,6 +59,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -66,7 +68,8 @@ RUN apt-get update && \
 
 FROM ${teamcityMinimalAgentImage}
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -58,9 +58,8 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    sed -i 's/git lfs install/git lfs install --system/' git-lfs-${GIT_LFS_VERSION}/install.sh && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -58,8 +58,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    sed -i 's/git lfs install/git lfs install --system/' git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -72,7 +73,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 USER root
 

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -59,8 +59,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    sed -i 's/git lfs install/git lfs install --system/' git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -73,7 +74,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 USER root
 

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -141,7 +141,8 @@ RUN apt-get update && \
 # Other
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
-    usermod -aG docker buildagent
+    usermod -aG docker buildagent && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -142,7 +142,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chown -R buildagent:buildagent /services && \
     usermod -aG docker buildagent && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 # A better fix for TW-52939 Dockerfile build fails because of aufs
 VOLUME /var/lib/docker

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -60,6 +60,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -67,7 +69,8 @@ RUN apt-get update && \
 
 FROM ${teamcityMinimalAgentImage}
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -59,9 +59,8 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
+    sed -i 's/git lfs install/git lfs install --system/' git-lfs-${GIT_LFS_VERSION}/install.sh && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 
 COPY welcome.sh /welcome.sh

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -75,7 +75,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxComponent
@@ -116,7 +116,9 @@ RUN apt-get update && \
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -47,6 +47,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -68,7 +70,8 @@ RUN apt-get update && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 
 COPY welcome.sh /welcome.sh

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -75,7 +75,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxComponent
@@ -116,7 +116,9 @@ RUN apt-get update && \
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -47,6 +47,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -68,7 +70,8 @@ RUN apt-get update && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 
 COPY welcome.sh /welcome.sh

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -75,7 +75,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxComponent
@@ -116,7 +116,9 @@ RUN apt-get update && \
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -47,6 +47,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -68,7 +70,8 @@ RUN apt-get update && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -47,7 +47,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -48,8 +48,6 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -76,7 +76,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxARM64Component

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -116,7 +116,8 @@ RUN apt-get update && \
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -48,6 +48,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -69,7 +71,8 @@ RUN apt-get update && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -47,7 +47,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -48,8 +48,6 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -76,7 +76,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxARM64Component

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -116,7 +116,8 @@ RUN apt-get update && \
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -48,6 +48,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -69,7 +71,8 @@ RUN apt-get update && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -47,7 +47,9 @@ RUN apt-get update && \
     # Install Git LFS
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
-    ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    PREFIX="/usr" ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Copy configuration with Git LFS filter
+    cp ~/.gitconfig /etc/gitconfig && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -48,8 +48,6 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
-    # Apply filters globally
-    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -117,7 +117,7 @@ RUN apt-get update && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
+    [ -f /etc/gitconfig ] || (echo "'/etc/gitconfig' does not exist, while LFS filter is required" && exit 1)
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     # Install Git
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz && \
     curl -O https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz.sig && \
-    tar -xvzf git-${GIT_VERSION}.tar.gz && \
+    tar -xzf git-${GIT_VERSION}.tar.gz && \
     cd git-${GIT_VERSION} && \
     make configure && ./configure --prefix=/usr && \
     make all && \

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -76,7 +76,7 @@ COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core
-COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=builder /usr/bin/git-lfs /usr/bin/git-lfs
 
 # JDK preparation start
 ARG jdkServerLinuxARM64Component

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -116,7 +116,8 @@ RUN apt-get update && \
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \
     # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    [ -f /etc/gitconfig ] || (echo "Git configuration '/etc/gitconfig' does not exist, causing Git LFS to break" && exit 1)
 
 COPY welcome.sh /welcome.sh
 COPY run-server.sh /run-server.sh

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -48,6 +48,8 @@ RUN apt-get update && \
     curl -sLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz && \
     mkdir git-lfs-${GIT_LFS_VERSION} && tar -xzf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz -C git-lfs-${GIT_LFS_VERSION} --strip-components 1 && \
     ./git-lfs-${GIT_LFS_VERSION}/install.sh && \
+    # Apply filters globally
+    git lfs install --system && \
     # Clean up
     rm -rf git-lfs-linux-arm64-${GIT_LFS_VERSION}.tar.gz git-lfs-${GIT_LFS_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -69,7 +71,8 @@ RUN apt-get update && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8
 
-# Copy compiled Git and Git LFS from the builder stage
+# Copy compiled Git, Git LFS and its configuration from the builder stage
+COPY --from=builder /etc/gitconfig /etc/gitconfig
 COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=builder /usr/share/git-core /usr/share/git-core


### PR DESCRIPTION
TeamCity Agent does not clone/fetch the actual LFS file but only fetches the stub (a pointer). This is caused by missing configuration entries related to the smudge, therefore a real file is not loaded from the LFS server.

To fix the issue for the **affected** images, you can build a custom one using the following Dockerfile:
```
# Please ensure that you update the base image according to your needs (AMD/ARM, non-sudo/sudo)
FROM jetbrains/teamcity-agent:2025.03-linux-arm64
USER root
RUN git lfs install --system
USER buildagent
```