### PR TITLE
[TW-93961]  Docker: update Git within Windows Docker images to Git 2.49.0

### DIFF
--- a/configs/windows.config
+++ b/configs/windows.config
@@ -1,9 +1,9 @@
 windowsPlatform=windows
 
 # https://github.com/git-for-windows/git/releases/
-gitWindowsComponent=https://${proxyUrl}github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip
-gitWindowsComponentSHA256=50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a
-gitWindowsComponentName=Git x64 v.2.47.1 Checksum (SHA256) ${gitWindowsComponentSHA256}
+gitWindowsComponent=https://${proxyUrl}github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip
+gitWindowsComponentSHA256=971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5
+gitWindowsComponentName=Git x64 v.2.49.0 Checksum (SHA256) ${gitWindowsComponentSHA256}
 
 # JDK for TeamCity Server
 # https://github.com/corretto/corretto-21/releases

--- a/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
@@ -1,8 +1,8 @@
 # Default arguments
 ARG dotnetWindowsComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-win-x64.zip'
 ARG dotnetWindowsComponentSHA512='88095e181228e9e496574ed6f36582303533369cd253f41abad6c3aaa7d23436736a3fb1dd6c908032b2cfda445f66d50628516395783bef3d5ee9bbb00edcd2'
-ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
-ARG gitWindowsComponentSHA256='50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip'
+ARG gitWindowsComponentSHA256='971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5'
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='20023c16bbc60d518ee7f8ca040a8c58'
 ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi'

--- a/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
@@ -1,8 +1,8 @@
 # Default arguments
 ARG dotnetWindowsComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-win-x64.zip'
 ARG dotnetWindowsComponentSHA512='88095e181228e9e496574ed6f36582303533369cd253f41abad6c3aaa7d23436736a3fb1dd6c908032b2cfda445f66d50628516395783bef3d5ee9bbb00edcd2'
-ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
-ARG gitWindowsComponentSHA256='50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip'
+ARG gitWindowsComponentSHA256='971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5'
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='20023c16bbc60d518ee7f8ca040a8c58'
 ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi'

--- a/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
@@ -1,8 +1,8 @@
 # Default arguments
 ARG dotnetWindowsComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-win-x64.zip'
 ARG dotnetWindowsComponentSHA512='88095e181228e9e496574ed6f36582303533369cd253f41abad6c3aaa7d23436736a3fb1dd6c908032b2cfda445f66d50628516395783bef3d5ee9bbb00edcd2'
-ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
-ARG gitWindowsComponentSHA256='50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip'
+ARG gitWindowsComponentSHA256='971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5'
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='20023c16bbc60d518ee7f8ca040a8c58'
 ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi'

--- a/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
@@ -1,8 +1,8 @@
 # Default arguments
 ARG dotnetWindowsComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-win-x64.zip'
 ARG dotnetWindowsComponentSHA512='88095e181228e9e496574ed6f36582303533369cd253f41abad6c3aaa7d23436736a3fb1dd6c908032b2cfda445f66d50628516395783bef3d5ee9bbb00edcd2'
-ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
-ARG gitWindowsComponentSHA256='50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip'
+ARG gitWindowsComponentSHA256='971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5'
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='20023c16bbc60d518ee7f8ca040a8c58'
 ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi'

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -1,8 +1,8 @@
 # Default arguments
 ARG dotnetWindowsComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.406/dotnet-sdk-8.0.406-win-x64.zip'
 ARG dotnetWindowsComponentSHA512='88095e181228e9e496574ed6f36582303533369cd253f41abad6c3aaa7d23436736a3fb1dd6c908032b2cfda445f66d50628516395783bef3d5ee9bbb00edcd2'
-ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
-ARG gitWindowsComponentSHA256='50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip'
+ARG gitWindowsComponentSHA256='971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5'
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='20023c16bbc60d518ee7f8ca040a8c58'
 ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi'

--- a/context/generated/windows/Server/nanoserver/1803/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1803/Dockerfile
@@ -1,5 +1,5 @@
 # Default arguments
-ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip'
 ARG jdkServerWindowsComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64-jdk.zip'
 ARG powershellImage='mcr.microsoft.com/powershell:nanoserver-1803'
 ARG windowsBuild='1803'

--- a/context/generated/windows/Server/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1809/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
-ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
-ARG gitWindowsComponentSHA256='50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip'
+ARG gitWindowsComponentSHA256='971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5'
 ARG jdkServerWindowsComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64-jdk.zip'
 ARG jdkServerWindowsComponentMD5SUM='20023c16bbc60d518ee7f8ca040a8c58'
 ARG nanoserverImage='mcr.microsoft.com/windows/nanoserver:1809'

--- a/context/generated/windows/Server/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1903/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
-ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
-ARG gitWindowsComponentSHA256='50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip'
+ARG gitWindowsComponentSHA256='971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5'
 ARG jdkServerWindowsComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64-jdk.zip'
 ARG jdkServerWindowsComponentMD5SUM='20023c16bbc60d518ee7f8ca040a8c58'
 ARG nanoserverImage='mcr.microsoft.com/windows/nanoserver:1903'

--- a/context/generated/windows/Server/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1909/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
-ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
-ARG gitWindowsComponentSHA256='50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip'
+ARG gitWindowsComponentSHA256='971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5'
 ARG jdkServerWindowsComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64-jdk.zip'
 ARG jdkServerWindowsComponentMD5SUM='20023c16bbc60d518ee7f8ca040a8c58'
 ARG nanoserverImage='mcr.microsoft.com/windows/nanoserver:1909'

--- a/context/generated/windows/Server/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/2022/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
-ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
-ARG gitWindowsComponentSHA256='50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a'
+ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip'
+ARG gitWindowsComponentSHA256='971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5'
 ARG jdkServerWindowsComponent='https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64-jdk.zip'
 ARG jdkServerWindowsComponentMD5SUM='20023c16bbc60d518ee7f8ca040a8c58'
 ARG nanoserverImage='mcr.microsoft.com/windows/nanoserver:ltsc2022'


### PR DESCRIPTION
Currently, Windows-based Docker images use Git version `2.47.1`, while Linux-based images have version 2.49.0. To keep things consistent, it is possible to update the Windows version to match.