### PR TITLE
[TW-94273] Docker: add legacy IPTables support to enable Docker-in-Docker on systems without nf_tables modules

### DIFF
--- a/context/run-docker.sh
+++ b/context/run-docker.sh
@@ -2,6 +2,23 @@
 
 if [ "$DOCKER_IN_DOCKER" = "start" ] ; then
 
+# By default, Docker in containers uses nftables. However, the host may be using legacy iptables.
+# This section optionally switches the container to use legacy iptables for Docker-in-Docker compatibility. See: TW-94273
+  if [ "$DOCKER_IPTABLES_LEGACY" == "1" ]; then
+       # Switch IPTables-related tools to legacy tables
+       sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+       sudo update-alternatives --install /usr/bin/iptables iptables /usr/sbin/iptables-nft 30
+       sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+
+       # Disable conflicting services
+       sudo systemctl disable --now ufw
+       sudo systemctl disable --now nftables
+       sudo apt update && apt install -t iptables-persistent
+
+       # Enable legacy tables by defaults
+       sudo systemctl enable --now iptables
+  fi
+
  # Do cover the case when the container is restarted:
  sudo rm /var/run/docker.pid 2>/dev/null
  sudo rm -rf /var/run/docker/containerd 2>/dev/null

--- a/context/run-docker.sh
+++ b/context/run-docker.sh
@@ -2,21 +2,43 @@
 
 if [ "$DOCKER_IN_DOCKER" = "start" ] ; then
 
-# By default, Docker in containers uses nftables. However, the host may be using legacy iptables.
-# This section optionally switches the container to use legacy iptables for Docker-in-Docker compatibility. See: TW-94273
+  # Cover the case when the host of the image uses legacy IPTables, see: TW-94273
   if [ "$DOCKER_IPTABLES_LEGACY" == "1" ]; then
-       # Switch IPTables-related tools to legacy tables
-       sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
-       sudo update-alternatives --install /usr/bin/iptables iptables /usr/sbin/iptables-nft 30
-       sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
 
-       # Disable conflicting services
-       sudo systemctl disable --now ufw
-       sudo systemctl disable --now nftables
-       sudo apt update && apt install -t iptables-persistent
+    # Prior to the switch, check the presence of existing IPTables (e.g., run-docker.sh is executed in runtime)
+    if iptables --version 2>/dev/null | grep -q "nf_tables"; then
+        rule_count=$(iptables -S 2>/dev/null | grep -v '^-P' | wc -l)
+        if [ "$rule_count" -gt 0 ]; then
+            echo "WARNING: Found $rule_count existing iptables rules using nftables backend."
+            echo "These rules will become invisible after switching to legacy but will still exist in kernel memory."
+            echo ""
+        fi
+    fi
 
-       # Enable legacy tables by defaults
-       sudo systemctl enable --now iptables
+    # Switch IPTables / IP6Tables and verify the switch
+    sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+    sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+    # Verify legacy mode has been enabled
+    for tool in iptables ip6tables; do
+        $tool --version | grep -q legacy || {
+            echo "ERROR: [$tool] is not running in legacy mode, even though legacy mode was requested"
+            exit 1
+        }
+    done
+
+    # Switch related tools and their alternatives to use legacy tables
+    for tool in iptables-save iptables-restore ip6tables-save ip6tables-restore; do
+        if update-alternatives --display $tool >/dev/null 2>&1; then
+          # NB! Format: ip6tables-save => ip6tables-legacy-save
+          legacy_tool="/usr/sbin/${tool%-*}-legacy-${tool#*-}"
+
+          if [ -f "$legacy_tool" ]; then
+            sudo update-alternatives --set $tool $legacy_tool
+            echo "[$tool] was set to legacy"
+          fi
+        fi
+    done
   fi
 
  # Do cover the case when the container is restarted:

--- a/dockerhub/teamcity-agent/README.md
+++ b/dockerhub/teamcity-agent/README.md
@@ -57,7 +57,7 @@ A TeamCity agent does not need manual upgrade: it will upgrade itself automatica
 - `AGENT_TOKEN` – (optional) Agent authorization token, if unset, the agent should be [authorized](https://www.jetbrains.com/help/teamcity/build-agent.html#BuildAgent-BuildAgentStatus) via TeamCity UI.
 - `OWN_ADDRESS` – (optional, Linux-only) IP address build agent binds to, autodetected  
 - `OWN_PORT` – (optional, Linux-only) Port build agent binds to, 9090 by default
-- `DOCKER_IN_DOCKER` – (optional, Linux-only) Run Docker within Docker.
+- `DOCKER_IN_DOCKER` – (optional, Linux-only) Run Docker within Docker. If the host does not have _nftables_ and uses legacy _iptables_, please add `DOCKER_IPTABLES_LEGACY=1` to switch to legacy iptables mode.
 
 ### Preserving Checkout Directories Between Builds
 


### PR DESCRIPTION
Currently, TeamCity Docker Images are using Docker 27.5.1 and IPTables 1.8.7 (NF).

The following known issues reported in the [Docker repository ](https://github.com/docker-library/docker)demonstrate that Docker-in-Docker fails to start up when the host system lacks the nf_tables module:

- [IPTables Change, can't run Gitlab CI CD anymore #464](https://github.com/docker-library/docker/issues/464)
- [dockerd fails to start - RULE_APPEND failed (No such file or directory): rule in chain DOCKER-ISOLATION-STAGE-1 #463](https://github.com/docker-library/docker/issues/463)

To support cases where TeamCity Agent with Docker-in-Docker runs on such hosts, it would be useful to provide the ability to conditionally switch to legacy IPTables.