### PR TITLE
[TW-96713] Update Mercurial SCM client within Windows-based Docker images: 6.1.1 -> 6.2.2

### DIFF
--- a/configs/windows.config
+++ b/configs/windows.config
@@ -23,5 +23,5 @@ dotnetWindowsComponent=https://${proxyUrl}builds.dotnet.microsoft.com/dotnet/Sdk
 dotnetWindowsComponentSHA512=904ed90eaa83083584d108a17f671113dd88bbe4485130bf818c8f3b12a717457b2cf29db7d3e66fbf959265bed851def1a890ec9a1349c8d0ff2ec08af65c7c
 dotnetWindowsComponentName=${dotnetComponentName} x86 Checksum (SHA512) ${dotnetWindowsComponentSHA512}
 
-mercurialWindowsComponentName=Mercurial x64 v.6.1.1
-mercurialWindowsComponent=https://${proxyUrl}www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi
+mercurialWindowsComponentName=Mercurial x64 v.6.2.2
+mercurialWindowsComponent=https://${proxyUrl}www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -487,7 +487,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.21.0.9.10.1 Checksum (MD5) 905e139bfc80a7c05333c22c3075fd87](https://corretto.aws/downloads/resources/21.0.9.10.1/amazon-corretto-21.0.9.10.1-windows-x64-jdk.zip)
 - [Git x64 v.2.51.1 Checksum (SHA256) ce0360b2bfcb60472064de698c8a5b73e63067320701fcd51d30a6e33d7967fa](https://github.com/git-for-windows/git/releases/download/v2.51.1.windows.1/MinGit-2.51.1-64-bit.zip)
 - [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
-- [Mercurial x64 v.6.1.1](https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi)
+- [Mercurial x64 v.6.2.2](https://www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi)
 - [.NET SDK v.8.0.415 (LTS) x86 Checksum (SHA512) 904ed90eaa83083584d108a17f671113dd88bbe4485130bf818c8f3b12a717457b2cf29db7d3e66fbf959265bed851def1a890ec9a1349c8d0ff2ec08af65c7c](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-win-x64.zip)
 
 Container platform: windows
@@ -522,7 +522,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.21.0.9.10.1 Checksum (MD5) 905e139bfc80a7c05333c22c3075fd87](https://corretto.aws/downloads/resources/21.0.9.10.1/amazon-corretto-21.0.9.10.1-windows-x64-jdk.zip)
 - [Git x64 v.2.51.1 Checksum (SHA256) ce0360b2bfcb60472064de698c8a5b73e63067320701fcd51d30a6e33d7967fa](https://github.com/git-for-windows/git/releases/download/v2.51.1.windows.1/MinGit-2.51.1-64-bit.zip)
 - [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
-- [Mercurial x64 v.6.1.1](https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi)
+- [Mercurial x64 v.6.2.2](https://www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi)
 - [.NET SDK v.8.0.415 (LTS) x86 Checksum (SHA512) 904ed90eaa83083584d108a17f671113dd88bbe4485130bf818c8f3b12a717457b2cf29db7d3e66fbf959265bed851def1a890ec9a1349c8d0ff2ec08af65c7c](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-win-x64.zip)
 
 Container platform: windows
@@ -795,7 +795,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.21.0.9.10.1 Checksum (MD5) 905e139bfc80a7c05333c22c3075fd87](https://corretto.aws/downloads/resources/21.0.9.10.1/amazon-corretto-21.0.9.10.1-windows-x64-jdk.zip)
 - [Git x64 v.2.51.1 Checksum (SHA256) ce0360b2bfcb60472064de698c8a5b73e63067320701fcd51d30a6e33d7967fa](https://github.com/git-for-windows/git/releases/download/v2.51.1.windows.1/MinGit-2.51.1-64-bit.zip)
 - [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
-- [Mercurial x64 v.6.1.1](https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi)
+- [Mercurial x64 v.6.2.2](https://www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi)
 - [.NET SDK v.8.0.415 (LTS) x86 Checksum (SHA512) 904ed90eaa83083584d108a17f671113dd88bbe4485130bf818c8f3b12a717457b2cf29db7d3e66fbf959265bed851def1a890ec9a1349c8d0ff2ec08af65c7c](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-win-x64.zip)
 
 Container platform: windows
@@ -826,7 +826,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.21.0.9.10.1 Checksum (MD5) 905e139bfc80a7c05333c22c3075fd87](https://corretto.aws/downloads/resources/21.0.9.10.1/amazon-corretto-21.0.9.10.1-windows-x64-jdk.zip)
 - [Git x64 v.2.51.1 Checksum (SHA256) ce0360b2bfcb60472064de698c8a5b73e63067320701fcd51d30a6e33d7967fa](https://github.com/git-for-windows/git/releases/download/v2.51.1.windows.1/MinGit-2.51.1-64-bit.zip)
 - [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
-- [Mercurial x64 v.6.1.1](https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi)
+- [Mercurial x64 v.6.2.2](https://www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi)
 - [.NET SDK v.8.0.415 (LTS) x86 Checksum (SHA512) 904ed90eaa83083584d108a17f671113dd88bbe4485130bf818c8f3b12a717457b2cf29db7d3e66fbf959265bed851def1a890ec9a1349c8d0ff2ec08af65c7c](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-win-x64.zip)
 
 Container platform: windows
@@ -858,7 +858,7 @@ Installed components:
 - [JDK <img align="center" height="18" src="/docs/media/corretto.png"> Amazon Corretto x64 v.21.0.9.10.1 Checksum (MD5) 905e139bfc80a7c05333c22c3075fd87](https://corretto.aws/downloads/resources/21.0.9.10.1/amazon-corretto-21.0.9.10.1-windows-x64-jdk.zip)
 - [Git x64 v.2.51.1 Checksum (SHA256) ce0360b2bfcb60472064de698c8a5b73e63067320701fcd51d30a6e33d7967fa](https://github.com/git-for-windows/git/releases/download/v2.51.1.windows.1/MinGit-2.51.1-64-bit.zip)
 - [PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
-- [Mercurial x64 v.6.1.1](https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi)
+- [Mercurial x64 v.6.2.2](https://www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi)
 - [.NET SDK v.8.0.415 (LTS) x86 Checksum (SHA512) 904ed90eaa83083584d108a17f671113dd88bbe4485130bf818c8f3b12a717457b2cf29db7d3e66fbf959265bed851def1a890ec9a1349c8d0ff2ec08af65c7c](https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-win-x64.zip)
 
 Container platform: windows

--- a/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
@@ -5,7 +5,7 @@ ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/downloa
 ARG gitWindowsComponentSHA256='ce0360b2bfcb60472064de698c8a5b73e63067320701fcd51d30a6e33d7967fa'
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/21.0.9.10.1/amazon-corretto-21.0.9.10.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='905e139bfc80a7c05333c22c3075fd87'
-ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi'
+ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-nanoserver-1803'
 ARG windowsservercoreImage='mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-1803'
 

--- a/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
@@ -5,7 +5,7 @@ ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/downloa
 ARG gitWindowsComponentSHA256='ce0360b2bfcb60472064de698c8a5b73e63067320701fcd51d30a6e33d7967fa'
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/21.0.9.10.1/amazon-corretto-21.0.9.10.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='905e139bfc80a7c05333c22c3075fd87'
-ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi'
+ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-nanoserver-1809'
 ARG windowsservercoreImage='mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019'
 

--- a/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
@@ -5,7 +5,7 @@ ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/downloa
 ARG gitWindowsComponentSHA256='ce0360b2bfcb60472064de698c8a5b73e63067320701fcd51d30a6e33d7967fa'
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/21.0.9.10.1/amazon-corretto-21.0.9.10.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='905e139bfc80a7c05333c22c3075fd87'
-ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi'
+ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-nanoserver-1903'
 ARG windowsservercoreImage='mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-1903'
 

--- a/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
@@ -5,7 +5,7 @@ ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/downloa
 ARG gitWindowsComponentSHA256='ce0360b2bfcb60472064de698c8a5b73e63067320701fcd51d30a6e33d7967fa'
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/21.0.9.10.1/amazon-corretto-21.0.9.10.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='905e139bfc80a7c05333c22c3075fd87'
-ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi'
+ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-nanoserver-1909'
 ARG windowsservercoreImage='mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-1909'
 

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -5,7 +5,7 @@ ARG gitWindowsComponent='https://github.com/git-for-windows/git/releases/downloa
 ARG gitWindowsComponentSHA256='ce0360b2bfcb60472064de698c8a5b73e63067320701fcd51d30a6e33d7967fa'
 ARG jdkWindowsComponent='https://corretto.aws/downloads/resources/21.0.9.10.1/amazon-corretto-21.0.9.10.1-windows-x64-jdk.zip'
 ARG jdkWindowsComponentMD5SUM='905e139bfc80a7c05333c22c3075fd87'
-ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.1.1-x64.msi'
+ARG mercurialWindowsComponent='https://www.mercurial-scm.org/release/windows/mercurial-6.2.2-x64.msi'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-nanoserver-2022'
 ARG windowsservercoreImage='mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022'
 


### PR DESCRIPTION
This pull request is dedicated to updating the Mercurial SCM in TeamCity Docker images in context of [TW-96713](https://youtrack.jetbrains.com/issue/TW-96713)

Due to compatibility limitations, the update is applied only to Windows-based Docker images.