### PR TITLE
[TW-98138] Agent images: explicitly define group and user ID for 'buildagent'

### DIFF
--- a/configs/linux/MinimalAgent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/MinimalAgent/Ubuntu/Ubuntu.Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    useradd -m buildagent
+    groupadd -g 999 tcuser || true && \
+    useradd -m -u 1000 -g 999 buildagent
 
 # JDK
 ARG jdkLinuxComponent

--- a/configs/linux/MinimalAgent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/MinimalAgent/Ubuntu/Ubuntu.Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser && \
+    groupadd -g 999 buildagent && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/configs/linux/MinimalAgent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/MinimalAgent/Ubuntu/Ubuntu.Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser || true && \
+    groupadd -g 999 tcuser && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/configs/linux/MinimalAgent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/MinimalAgent/UbuntuARM/UbuntuARM.Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser && \
+    groupadd -g 999 buildagent && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/configs/linux/MinimalAgent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/MinimalAgent/UbuntuARM/UbuntuARM.Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    useradd -m buildagent
+    groupadd -g 999 tcuser || true && \
+    useradd -m -u 1000 -g 999 buildagent
 
 # JDK
 ARG jdkLinuxARM64Component

--- a/configs/linux/MinimalAgent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/MinimalAgent/UbuntuARM/UbuntuARM.Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser || true && \
+    groupadd -g 999 tcuser && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/18.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser && \
+    groupadd -g 999 buildagent && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/18.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser || true && \
+    groupadd -g 999 tcuser && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/18.04/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    useradd -m buildagent
+    groupadd -g 999 tcuser || true && \
+    useradd -m -u 1000 -g 999 buildagent
 
 # JDK
 ARG jdkLinuxComponent

--- a/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser && \
+    groupadd -g 999 buildagent && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser || true && \
+    groupadd -g 999 tcuser && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    useradd -m buildagent
+    groupadd -g 999 tcuser || true && \
+    useradd -m -u 1000 -g 999 buildagent
 
 # JDK
 ARG jdkLinuxComponent

--- a/context/generated/linux/MinimalAgent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/22.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser && \
+    groupadd -g 999 buildagent && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/22.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser || true && \
+    groupadd -g 999 tcuser && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/22.04/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    useradd -m buildagent
+    groupadd -g 999 tcuser || true && \
+    useradd -m -u 1000 -g 999 buildagent
 
 # JDK
 ARG jdkLinuxComponent

--- a/context/generated/linux/MinimalAgent/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/24.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser && \
+    groupadd -g 999 buildagent && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/24.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser || true && \
+    groupadd -g 999 tcuser && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/24.04/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    useradd -m buildagent
+    groupadd -g 999 tcuser || true && \
+    useradd -m -u 1000 -g 999 buildagent
 
 # JDK
 ARG jdkLinuxComponent

--- a/context/generated/linux/MinimalAgent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/18.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser && \
+    groupadd -g 999 buildagent && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/18.04/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    useradd -m buildagent
+    groupadd -g 999 tcuser || true && \
+    useradd -m -u 1000 -g 999 buildagent
 
 # JDK
 ARG jdkLinuxARM64Component

--- a/context/generated/linux/MinimalAgent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/18.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser || true && \
+    groupadd -g 999 tcuser && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/20.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser && \
+    groupadd -g 999 buildagent && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/20.04/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    useradd -m buildagent
+    groupadd -g 999 tcuser || true && \
+    useradd -m -u 1000 -g 999 buildagent
 
 # JDK
 ARG jdkLinuxARM64Component

--- a/context/generated/linux/MinimalAgent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/20.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser || true && \
+    groupadd -g 999 tcuser && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/22.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser && \
+    groupadd -g 999 buildagent && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/22.04/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    useradd -m buildagent
+    groupadd -g 999 tcuser || true && \
+    useradd -m -u 1000 -g 999 buildagent
 
 # JDK
 ARG jdkLinuxARM64Component

--- a/context/generated/linux/MinimalAgent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/22.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser || true && \
+    groupadd -g 999 tcuser && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/24.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser && \
+    groupadd -g 999 buildagent && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK

--- a/context/generated/linux/MinimalAgent/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/24.04/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    useradd -m buildagent
+    groupadd -g 999 tcuser || true && \
+    useradd -m -u 1000 -g 999 buildagent
 
 # JDK
 ARG jdkLinuxARM64Component

--- a/context/generated/linux/MinimalAgent/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/24.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 tcuser || true && \
+    groupadd -g 999 tcuser && \
     useradd -m -u 1000 -g 999 buildagent
 
 # JDK


### PR DESCRIPTION
[Recently](https://github.com/JetBrains/teamcity-docker-images/pull/227), we aligned the agent images with the server images by adopting the same approach of removing the `ubuntu` user, ensuring that the user ID remains consistent with pre-2025.11 (UID 1000).

However, since the target UID is not explicitly defined, this approach introduces a potential risk. If another user were to be created with UID 1000, builduser would automatically be assigned the next available UID, and the issue could go unnoticed.

This merge request addresses that risk. The image build will fail if the `1000` UID is unavailable.