### PR TITLE
[TW] Align GID and UID for 'buildagent' user

### DIFF
--- a/configs/linux/MinimalAgent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/MinimalAgent/Ubuntu/Ubuntu.Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 buildagent && \
-    useradd -m -u 1000 -g 999 buildagent
+    groupadd -g 1000 buildagent && \
+    useradd -m -u 1000 -g 1000 buildagent
 
 # JDK
 ARG jdkLinuxComponent

--- a/configs/linux/MinimalAgent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/MinimalAgent/UbuntuARM/UbuntuARM.Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 buildagent && \
-    useradd -m -u 1000 -g 999 buildagent
+    groupadd -g 1000 buildagent && \
+    useradd -m -u 1000 -g 1000 buildagent
 
 # JDK
 ARG jdkLinuxARM64Component

--- a/context/generated/linux/MinimalAgent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/18.04/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 buildagent && \
-    useradd -m -u 1000 -g 999 buildagent
+    groupadd -g 1000 buildagent && \
+    useradd -m -u 1000 -g 1000 buildagent
 
 # JDK
 ARG jdkLinuxComponent

--- a/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 buildagent && \
-    useradd -m -u 1000 -g 999 buildagent
+    groupadd -g 1000 buildagent && \
+    useradd -m -u 1000 -g 1000 buildagent
 
 # JDK
 ARG jdkLinuxComponent

--- a/context/generated/linux/MinimalAgent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/22.04/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 buildagent && \
-    useradd -m -u 1000 -g 999 buildagent
+    groupadd -g 1000 buildagent && \
+    useradd -m -u 1000 -g 1000 buildagent
 
 # JDK
 ARG jdkLinuxComponent

--- a/context/generated/linux/MinimalAgent/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/24.04/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 buildagent && \
-    useradd -m -u 1000 -g 999 buildagent
+    groupadd -g 1000 buildagent && \
+    useradd -m -u 1000 -g 1000 buildagent
 
 # JDK
 ARG jdkLinuxComponent

--- a/context/generated/linux/MinimalAgent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/18.04/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 buildagent && \
-    useradd -m -u 1000 -g 999 buildagent
+    groupadd -g 1000 buildagent && \
+    useradd -m -u 1000 -g 1000 buildagent
 
 # JDK
 ARG jdkLinuxARM64Component

--- a/context/generated/linux/MinimalAgent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/20.04/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 buildagent && \
-    useradd -m -u 1000 -g 999 buildagent
+    groupadd -g 1000 buildagent && \
+    useradd -m -u 1000 -g 1000 buildagent
 
 # JDK
 ARG jdkLinuxARM64Component

--- a/context/generated/linux/MinimalAgent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/22.04/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 buildagent && \
-    useradd -m -u 1000 -g 999 buildagent
+    groupadd -g 1000 buildagent && \
+    useradd -m -u 1000 -g 1000 buildagent
 
 # JDK
 ARG jdkLinuxARM64Component

--- a/context/generated/linux/MinimalAgent/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/UbuntuARM/24.04/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
 # Delete the default Ubuntu user if it exists with a conflicting UID. See: https://bugs.launchpad.net/cloud-images/+bug/2005129
     if id -u ubuntu >/dev/null 2>&1 && [ "$(id -u ubuntu)" -eq 1000 ]; then userdel -r -f ubuntu; fi && \
-    groupadd -g 999 buildagent && \
-    useradd -m -u 1000 -g 999 buildagent
+    groupadd -g 1000 buildagent && \
+    useradd -m -u 1000 -g 1000 buildagent
 
 # JDK
 ARG jdkLinuxARM64Component


### PR DESCRIPTION
This merge request aligns the UID and GID of the buildagent user, allowing existing scripts that assume 1000:1000 permissions to run correctly.