### PR TITLE
[TW-100061] Windows Docker images: the dotCover { … } step fails due to non-canonical ACLs

### DIFF
--- a/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
@@ -101,15 +101,15 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
@@ -107,9 +107,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
@@ -109,7 +109,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer1809.Dockerfile
@@ -101,7 +101,10 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
@@ -110,7 +110,10 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
@@ -110,15 +110,15 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r '*S-1-5-32-545:(OI)(CI)F' /grant:r '*S-1-5-93-2-2:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
@@ -118,7 +118,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Agent/nanoserver/NanoServer2022.Dockerfile
@@ -116,9 +116,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r '*S-1-5-32-545:(OI)(CI)F' /grant:r '*S-1-5-93-2-2:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
@@ -107,6 +107,6 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
@@ -103,6 +103,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
+    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
@@ -103,10 +103,10 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
+    icacls.exe C:\BuildAgent /reset /T ; \
+    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    icacls.exe C:\BuildAgent /reset /T ; \
-    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore1803.Dockerfile
@@ -105,8 +105,9 @@ USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
-    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
@@ -111,9 +111,10 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     if (Test-Path 'C:\BuildAgent\conf\buildAgent.properties') { Remove-Item -Force 'C:\BuildAgent\conf\buildAgent.properties' } ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
-    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     icacls.exe 'C:\BuildAgent\*'
 
 USER ContainerUser

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
@@ -113,7 +113,7 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe 'C:\BuildAgent\*'
 
 USER ContainerUser

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
@@ -109,6 +109,9 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     New-Item -ItemType Directory -Force -Path C:\BuildAgent\logs, C:\BuildAgent\work, C:\BuildAgent\conf | Out-Null ; \
     New-Item -ItemType File -Force -Path C:\BuildAgent\logs\.keep, C:\BuildAgent\work\.keep, C:\BuildAgent\conf\.keep | Out-Null ; \
     if (Test-Path 'C:\BuildAgent\conf\buildAgent.properties') { Remove-Item -Force 'C:\BuildAgent\conf\buildAgent.properties' } ; \
+    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'

--- a/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
+++ b/configs/windows/Agent/windowsservercore/WindowsServerCore2022.Dockerfile
@@ -109,11 +109,11 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     New-Item -ItemType Directory -Force -Path C:\BuildAgent\logs, C:\BuildAgent\work, C:\BuildAgent\conf | Out-Null ; \
     New-Item -ItemType File -Force -Path C:\BuildAgent\logs\.keep, C:\BuildAgent\work\.keep, C:\BuildAgent\conf\.keep | Out-Null ; \
     if (Test-Path 'C:\BuildAgent\conf\buildAgent.properties') { Remove-Item -Force 'C:\BuildAgent\conf\buildAgent.properties' } ; \
+    icacls.exe C:\BuildAgent /reset /T ; \
+    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    icacls.exe C:\BuildAgent /reset /T ; \
-    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'
 
 USER ContainerUser

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
@@ -98,7 +98,10 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
@@ -104,9 +104,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
@@ -98,15 +98,15 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer1809.Dockerfile
@@ -106,7 +106,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -106,9 +106,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -108,7 +108,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -100,15 +100,15 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/MinimalAgent/nanoserver/NanoServer2022.Dockerfile
@@ -100,7 +100,10 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
@@ -115,6 +115,7 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
     cmd /c icacls.exe C:\\TeamCity\\*

--- a/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
@@ -117,7 +117,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { <# Canonicalizing ACLs to prevent issues such as TW-100061 #> $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; $acl = Get-Acl 'C:\TeamCity'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\TeamCity' } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
@@ -115,9 +115,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer1809.Dockerfile
@@ -117,7 +117,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/configs/windows/Server/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer2022.Dockerfile
@@ -121,7 +121,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/configs/windows/Server/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer2022.Dockerfile
@@ -121,7 +121,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { <# Canonicalizing ACLs to prevent issues such as TW-100061 #> $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; $acl = Get-Acl 'C:\TeamCity'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\TeamCity' } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/configs/windows/Server/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer2022.Dockerfile
@@ -119,9 +119,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/configs/windows/Server/nanoserver/NanoServer2022.Dockerfile
+++ b/configs/windows/Server/nanoserver/NanoServer2022.Dockerfile
@@ -119,6 +119,7 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
     cmd /c icacls.exe C:\\TeamCity\\*

--- a/context/generated/windows/Agent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1809/Dockerfile
@@ -91,15 +91,15 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1809/Dockerfile
@@ -99,7 +99,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1809/Dockerfile
@@ -97,9 +97,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1809/Dockerfile
@@ -91,7 +91,10 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/context/generated/windows/Agent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1903/Dockerfile
@@ -91,15 +91,15 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1903/Dockerfile
@@ -99,7 +99,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1903/Dockerfile
@@ -97,9 +97,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1903/Dockerfile
@@ -91,7 +91,10 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/context/generated/windows/Agent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1909/Dockerfile
@@ -91,15 +91,15 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1909/Dockerfile
@@ -99,7 +99,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1909/Dockerfile
@@ -97,9 +97,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/1909/Dockerfile
@@ -91,7 +91,10 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/context/generated/windows/Agent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/2022/Dockerfile
@@ -100,7 +100,10 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/context/generated/windows/Agent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/2022/Dockerfile
@@ -108,7 +108,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/2022/Dockerfile
@@ -106,9 +106,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r '*S-1-5-32-545:(OI)(CI)F' /grant:r '*S-1-5-93-2-2:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Agent/nanoserver/2022/Dockerfile
@@ -100,15 +100,15 @@ RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd;C:\Program Fil
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r '*S-1-5-32-545:(OI)(CI)F' /grant:r '*S-1-5-93-2-2:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
@@ -102,6 +102,6 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
@@ -98,10 +98,10 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
+    icacls.exe C:\BuildAgent /reset /T ; \
+    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    icacls.exe C:\BuildAgent /reset /T ; \
-    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
@@ -98,6 +98,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
+    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'

--- a/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1803/Dockerfile
@@ -100,8 +100,9 @@ USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
-    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
@@ -102,6 +102,6 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
@@ -98,10 +98,10 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
+    icacls.exe C:\BuildAgent /reset /T ; \
+    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    icacls.exe C:\BuildAgent /reset /T ; \
-    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
@@ -98,6 +98,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
+    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'

--- a/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1809/Dockerfile
@@ -100,8 +100,9 @@ USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
-    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
@@ -102,6 +102,6 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
@@ -98,10 +98,10 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
+    icacls.exe C:\BuildAgent /reset /T ; \
+    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    icacls.exe C:\BuildAgent /reset /T ; \
-    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
@@ -98,6 +98,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
+    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'

--- a/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1903/Dockerfile
@@ -100,8 +100,9 @@ USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
-    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
@@ -102,6 +102,6 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
@@ -98,10 +98,10 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
+    icacls.exe C:\BuildAgent /reset /T ; \
+    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    icacls.exe C:\BuildAgent /reset /T ; \
-    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
@@ -98,6 +98,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
+    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'

--- a/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/1909/Dockerfile
@@ -100,8 +100,9 @@ USER ContainerAdministrator
 RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercurial' -f $env:PATH, $env:JAVA_HOME) ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
-    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     icacls.exe 'C:\BuildAgent\*'
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -104,11 +104,11 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     New-Item -ItemType Directory -Force -Path C:\BuildAgent\logs, C:\BuildAgent\work, C:\BuildAgent\conf | Out-Null ; \
     New-Item -ItemType File -Force -Path C:\BuildAgent\logs\.keep, C:\BuildAgent\work\.keep, C:\BuildAgent\conf\.keep | Out-Null ; \
     if (Test-Path 'C:\BuildAgent\conf\buildAgent.properties') { Remove-Item -Force 'C:\BuildAgent\conf\buildAgent.properties' } ; \
+    icacls.exe C:\BuildAgent /reset /T ; \
+    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    icacls.exe C:\BuildAgent /reset /T ; \
-    icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'
 
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -106,9 +106,10 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     if (Test-Path 'C:\BuildAgent\conf\buildAgent.properties') { Remove-Item -Force 'C:\BuildAgent\conf\buildAgent.properties' } ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
-    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     icacls.exe 'C:\BuildAgent\*'
 
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -108,7 +108,7 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe 'C:\BuildAgent\*'
 
 USER ContainerUser

--- a/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
+++ b/context/generated/windows/Agent/windowsservercore/2022/Dockerfile
@@ -104,6 +104,9 @@ RUN setx /M PATH ('{0};{1}\bin;C:\Program Files\Git\cmd;C:\Program Files\Mercuri
     New-Item -ItemType Directory -Force -Path C:\BuildAgent\logs, C:\BuildAgent\work, C:\BuildAgent\conf | Out-Null ; \
     New-Item -ItemType File -Force -Path C:\BuildAgent\logs\.keep, C:\BuildAgent\work\.keep, C:\BuildAgent\conf\.keep | Out-Null ; \
     if (Test-Path 'C:\BuildAgent\conf\buildAgent.properties') { Remove-Item -Force 'C:\BuildAgent\conf\buildAgent.properties' } ; \
+    <# Fix non-canonical ACLs: re-writing via Set-Acl forces Windows to sort ACEs into canonical order #> \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     icacls.exe C:\BuildAgent /reset /T ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     icacls.exe 'C:\BuildAgent\*'

--- a/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
@@ -99,7 +99,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
@@ -97,9 +97,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
@@ -91,7 +91,10 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1809/Dockerfile
@@ -91,15 +91,15 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
@@ -99,7 +99,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
@@ -97,9 +97,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
@@ -91,7 +91,10 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1903/Dockerfile
@@ -91,15 +91,15 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
@@ -99,7 +99,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
@@ -97,9 +97,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
@@ -91,7 +91,10 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/1909/Dockerfile
@@ -91,15 +91,15 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -99,9 +99,11 @@ RUN Write-Host 'Resetting ACLs...' ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    <# Canonicalizing ACLs to prevent issues such as TW-100061 #> \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
     Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    $acl = Get-Acl 'C:\BuildAgent'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\BuildAgent' }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -101,7 +101,7 @@ RUN Write-Host 'Resetting ACLs...' ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Canonicalizing ACLs...' ; \
     $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -93,15 +93,15 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Canonicalizing ACLs...' ; \
-    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
-    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
-    Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \
     icacls.exe C:\BuildAgent /grant:r 'DefaultAccount:(OI)(CI)F' /grant:r 'Users:(OI)(CI)F' /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls grant failed with exit code ' + $LASTEXITCODE) } ; \
+    Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
     Write-Host 'Verifying permissions:' ; \
     icacls.exe C:\BuildAgent\conf ; \
     icacls.exe C:\BuildAgent\*

--- a/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/MinimalAgent/nanoserver/2022/Dockerfile
@@ -93,7 +93,10 @@ RUN if not exist C:\BuildAgent\logs md C:\BuildAgent\logs && \
 
 # Reset and grant permissions in PowerShell for proper error handling
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-RUN Write-Host 'Resetting ACLs...' ; \
+RUN Write-Host 'Canonicalizing ACLs...' ; \
+    $acl = Get-Acl 'C:\BuildAgent'; Set-Acl 'C:\BuildAgent' $acl; \
+    Get-ChildItem 'C:\BuildAgent' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; \
+    Write-Host 'Resetting ACLs...' ; \
     icacls.exe C:\BuildAgent /reset /T ; \
     if ($LASTEXITCODE -ne 0) { throw ('icacls reset failed with exit code ' + $LASTEXITCODE) } ; \
     Write-Host 'Granting permissions...' ; \

--- a/context/generated/windows/Server/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1809/Dockerfile
@@ -113,7 +113,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { <# Canonicalizing ACLs to prevent issues such as TW-100061 #> $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; $acl = Get-Acl 'C:\TeamCity'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\TeamCity' } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1809/Dockerfile
@@ -113,7 +113,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1809/Dockerfile
@@ -111,6 +111,7 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
     cmd /c icacls.exe C:\\TeamCity\\*

--- a/context/generated/windows/Server/nanoserver/1809/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1809/Dockerfile
@@ -111,9 +111,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1903/Dockerfile
@@ -113,7 +113,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { <# Canonicalizing ACLs to prevent issues such as TW-100061 #> $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; $acl = Get-Acl 'C:\TeamCity'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\TeamCity' } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1903/Dockerfile
@@ -113,7 +113,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1903/Dockerfile
@@ -111,6 +111,7 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
     cmd /c icacls.exe C:\\TeamCity\\*

--- a/context/generated/windows/Server/nanoserver/1903/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1903/Dockerfile
@@ -111,9 +111,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1909/Dockerfile
@@ -113,7 +113,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { <# Canonicalizing ACLs to prevent issues such as TW-100061 #> $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; $acl = Get-Acl 'C:\TeamCity'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\TeamCity' } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1909/Dockerfile
@@ -113,7 +113,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1909/Dockerfile
@@ -111,6 +111,7 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
     cmd /c icacls.exe C:\\TeamCity\\*

--- a/context/generated/windows/Server/nanoserver/1909/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/1909/Dockerfile
@@ -111,9 +111,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/2022/Dockerfile
@@ -115,6 +115,7 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
     cmd /c icacls.exe C:\\TeamCity\\*

--- a/context/generated/windows/Server/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/2022/Dockerfile
@@ -117,7 +117,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { <# Canonicalizing ACLs to prevent issues such as TW-100061 #> $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a }; $acl = Get-Acl 'C:\TeamCity'; if (-not $acl.AreAccessRulesCanonical) { throw 'ACLs are not canonical after Set-Acl on C:\TeamCity' } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/2022/Dockerfile
@@ -115,9 +115,9 @@ USER ContainerAdministrator
 # Grant Permissions for ContainerUser (Default Account), OI - Object Inherit, CI - Container Inherit, ...
 # ... F - full control, /T - apply to subfolders & files
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 

--- a/context/generated/windows/Server/nanoserver/2022/Dockerfile
+++ b/context/generated/windows/Server/nanoserver/2022/Dockerfile
@@ -117,7 +117,7 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;%JAVA_HOME%\bin;C:\Program Files\Git\cmd" && \
     cmd /c icacls.exe C:\\TeamCity /reset /T && \
     cmd /c icacls.exe C:\\TeamCity /grant:r DefaultAccount:(OI)(CI)F /grant:r Users:(OI)(CI)F /T && \
-    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
+    pwsh -Command "& { $acl = Get-Acl 'C:\TeamCity'; Set-Acl 'C:\TeamCity' $acl; Get-ChildItem 'C:\TeamCity' -Recurse -Force | ForEach-Object { $a = Get-Acl $_.FullName; Set-Acl $_.FullName $a } }" && \
     cmd /c icacls.exe C:\\TeamCity\\*
 USER ContainerUser
 


### PR DESCRIPTION
**Steps to reproduce the problem:**
- Create a build configuration with dotCover { … } build step.
- Deploy a Windows-based Dockerized TeamCity agent and connect it to the server.
- Schedule the execution of a dotCover-related build configuration onto the agent deployed in (2).

**The actual result:**
* The dotCover { … } step fails, reporting that the ACL is not in canonical form.

Details: https://youtrack.jetbrains.com/issue/TW-100061/