### PR TITLE
[TW-99787] Update binary dependencies: Docker 28.5.1 -> 29.4.0

### DIFF
--- a/configs/linux.config
+++ b/configs/linux.config
@@ -27,8 +27,8 @@ gitLinuxComponentName=Git v.2.53.0
 gitLFSLinuxComponentVersion=v3.7.1
 gitLFSLinuxComponentName=Git LFS 3.7.1
 
-dockerLinuxComponentVersion=5:28.5.1-1~ubuntu
-dockerLinuxComponentName=[Docker v.28.5.1](https://docs.docker.com/engine/release-notes/28)
+dockerLinuxComponentVersion=5:29.4.0-1~ubuntu
+dockerLinuxComponentName=[Docker v.29.4.0](https://docs.docker.com/engine/release-notes/29)
 
 containerdIoLinuxComponentName=[Containerd.io 1.7.28-1](https://github.com/containerd/containerd/releases/tag/v1.7.28)
 containerdIoLinuxComponentVersion=1.7.28-1~ubuntu.24.04~noble

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.7.28-1~ubuntu.24.04~noble'
-ARG dockerLinuxComponentVersion='5:28.5.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:29.4.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='0fc0499a857f161f7c35775bb3f50ac6f0333f02f5df21d21147d538eb26a9a87282d4ba3707181c46f3c09d22cdc984e77820a5953a773525d6f7b332deb7f2'

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.7.28-1~ubuntu.24.04~noble'
-ARG dockerLinuxComponentVersion='5:28.5.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:29.4.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='0fc0499a857f161f7c35775bb3f50ac6f0333f02f5df21d21147d538eb26a9a87282d4ba3707181c46f3c09d22cdc984e77820a5953a773525d6f7b332deb7f2'

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.7.28-1~ubuntu.24.04~noble'
-ARG dockerLinuxComponentVersion='5:28.5.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:29.4.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='0fc0499a857f161f7c35775bb3f50ac6f0333f02f5df21d21147d538eb26a9a87282d4ba3707181c46f3c09d22cdc984e77820a5953a773525d6f7b332deb7f2'

--- a/context/generated/linux/Agent/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/24.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.7.28-1~ubuntu.24.04~noble'
-ARG dockerLinuxComponentVersion='5:28.5.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:29.4.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc-s1 libicu74 liblttng-ust1 libssl3 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='0fc0499a857f161f7c35775bb3f50ac6f0333f02f5df21d21147d538eb26a9a87282d4ba3707181c46f3c09d22cdc984e77820a5953a773525d6f7b332deb7f2'

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.7.28-1~ubuntu.24.04~noble'
-ARG dockerLinuxComponentVersion='5:28.5.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:29.4.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu60 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='c2efcccfd83690482d3314b23a9d9b53d41591795eb50e02857cb495dd1fde132f2c332dc243095463338d2dc6cd362cd7ea7ae3a9ce75b32ab54a517b91def8'

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.7.28-1~ubuntu.24.04~noble'
-ARG dockerLinuxComponentVersion='5:28.5.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:29.4.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='c2efcccfd83690482d3314b23a9d9b53d41591795eb50e02857cb495dd1fde132f2c332dc243095463338d2dc6cd362cd7ea7ae3a9ce75b32ab54a517b91def8'

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.7.28-1~ubuntu.24.04~noble'
-ARG dockerLinuxComponentVersion='5:28.5.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:29.4.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='c2efcccfd83690482d3314b23a9d9b53d41591795eb50e02857cb495dd1fde132f2c332dc243095463338d2dc6cd362cd7ea7ae3a9ce75b32ab54a517b91def8'

--- a/context/generated/linux/Agent/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/24.04/Dockerfile
@@ -1,6 +1,6 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.7.28-1~ubuntu.24.04~noble'
-ARG dockerLinuxComponentVersion='5:28.5.1-1~ubuntu'
+ARG dockerLinuxComponentVersion='5:29.4.0-1~ubuntu'
 ARG dotnetLibs='libc6 libgcc-s1 libicu74 liblttng-ust1 libssl3 libstdc++6 zlib1g'
 ARG dotnetLinuxARM64Component='https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.415/dotnet-sdk-8.0.415-linux-arm64.tar.gz'
 ARG dotnetLinuxARM64ComponentSHA512='c2efcccfd83690482d3314b23a9d9b53d41591795eb50e02857cb495dd1fde132f2c332dc243095463338d2dc6cd362cd7ea7ae3a9ce75b32ab54a517b91def8'


### PR DESCRIPTION
Details: [TW-99787](https://youtrack.jetbrains.com/issue/TW-99787) Docker images: Update binary dependencies for the 2026.1 release