### PR TITLE
[TW] Update Git installation process to workaround Git PPA's unavailability (504)

### DIFF
--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -101,13 +101,13 @@ RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -102,8 +102,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -98,16 +98,16 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    apt-get install -y mercurial && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev gnupg curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -98,10 +98,17 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial apt-transport-https && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -99,8 +99,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -96,15 +96,15 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -95,10 +95,17 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial apt-transport-https && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \

--- a/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Agent/UbuntuARM/UbuntuARM.Dockerfile
@@ -98,13 +98,13 @@ RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -107,13 +107,13 @@ RUN apt-get update && \
     apt-get install -y mercurial gnupg && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -105,15 +105,15 @@ ARG gitLinuxComponentVersion
 RUN apt-get update && \
      # Mercurial
     apt-get install -y mercurial gnupg && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -104,10 +104,17 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
      # Mercurial
-    apt-get install -y mercurial gnupg software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial gnupg && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Server/Ubuntu/Ubuntu.Dockerfile
@@ -108,8 +108,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -107,8 +107,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -106,13 +106,13 @@ RUN apt-get update && \
     apt-get install -y mercurial gnupg && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -51,8 +51,7 @@ FROM ${ubuntuImage}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip \
+
     # See: TW-91621
     netcat-openbsd \
     # Git & Git LFS Runtime dependencies
@@ -104,10 +103,17 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
     # Mercurial
-    apt-get install -y mercurial gnupg software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial gnupg && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
+++ b/configs/linux/Server/UbuntuARM/UbuntuARM.Dockerfile
@@ -104,15 +104,15 @@ ARG gitLinuxComponentVersion
 RUN apt-get update && \
     # Mercurial
     apt-get install -y mercurial gnupg && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -93,13 +93,13 @@ RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -90,10 +90,17 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial apt-transport-https && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -90,16 +90,16 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    apt-get install -y mercurial && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev gnupg curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/18.04/Dockerfile
@@ -94,8 +94,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -93,13 +93,13 @@ RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -90,10 +90,17 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial apt-transport-https && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -90,16 +90,16 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    apt-get install -y mercurial && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev gnupg curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -94,8 +94,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -95,8 +95,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -94,13 +94,13 @@ RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -91,16 +91,16 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    apt-get install -y mercurial && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev gnupg curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/22.04/Dockerfile
@@ -91,10 +91,17 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial apt-transport-https && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Agent/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/24.04/Dockerfile
@@ -95,8 +95,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Agent/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/24.04/Dockerfile
@@ -94,13 +94,13 @@ RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Agent/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/24.04/Dockerfile
@@ -91,16 +91,16 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    apt-get install -y mercurial && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev gnupg curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Agent/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/24.04/Dockerfile
@@ -91,10 +91,17 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial apt-transport-https && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -90,10 +90,17 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial apt-transport-https && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -93,13 +93,13 @@ RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -91,15 +91,15 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/18.04/Dockerfile
@@ -94,8 +94,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -90,10 +90,17 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial apt-transport-https && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -93,13 +93,13 @@ RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -91,15 +91,15 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/20.04/Dockerfile
@@ -94,8 +94,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -95,8 +95,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -94,13 +94,13 @@ RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -92,15 +92,15 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/22.04/Dockerfile
@@ -91,10 +91,17 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial apt-transport-https && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \

--- a/context/generated/linux/Agent/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/24.04/Dockerfile
@@ -95,8 +95,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Agent/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/24.04/Dockerfile
@@ -94,13 +94,13 @@ RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/context/generated/linux/Agent/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/24.04/Dockerfile
@@ -92,15 +92,15 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
     apt-get install -y mercurial apt-transport-https && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/context/generated/linux/Agent/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/Agent/UbuntuARM/24.04/Dockerfile
@@ -91,10 +91,17 @@ ARG p4Version
 ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial apt-transport-https && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
 # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -100,15 +100,15 @@ ARG gitLinuxComponentVersion
 RUN apt-get update && \
      # Mercurial
     apt-get install -y mercurial gnupg && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -102,13 +102,13 @@ RUN apt-get update && \
     apt-get install -y mercurial gnupg && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -103,8 +103,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/18.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.41.0-0ppa1~ubuntu18.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/21.0.10.7.1/amazon-corretto-21.0.10.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='7bf7339989b58c74fedbd58e26bb03ec'
 ARG p4Version='r25.2'
-ARG repo=''
 ARG ubuntuImage='ubuntu:18.04'
 
 # The list of required arguments
@@ -100,10 +99,17 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
      # Mercurial
-    apt-get install -y mercurial gnupg software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial gnupg && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -100,15 +100,15 @@ ARG gitLinuxComponentVersion
 RUN apt-get update && \
      # Mercurial
     apt-get install -y mercurial gnupg && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -102,13 +102,13 @@ RUN apt-get update && \
     apt-get install -y mercurial gnupg && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -103,8 +103,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/20.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.54.0-0ppa1~ubuntu24.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/21.0.10.7.1/amazon-corretto-21.0.10.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='7bf7339989b58c74fedbd58e26bb03ec'
 ARG p4Version='r25.2'
-ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG ubuntuImage='ubuntu:20.04'
 
 # The list of required arguments
@@ -100,10 +99,17 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
      # Mercurial
-    apt-get install -y mercurial gnupg software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial gnupg && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -100,15 +100,15 @@ ARG gitLinuxComponentVersion
 RUN apt-get update && \
      # Mercurial
     apt-get install -y mercurial gnupg && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -102,13 +102,13 @@ RUN apt-get update && \
     apt-get install -y mercurial gnupg && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.54.0-0ppa1~ubuntu24.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/21.0.10.7.1/amazon-corretto-21.0.10.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='7bf7339989b58c74fedbd58e26bb03ec'
 ARG p4Version='r25.2'
-ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG ubuntuImage='ubuntu:22.04'
 
 # The list of required arguments
@@ -100,10 +99,17 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
      # Mercurial
-    apt-get install -y mercurial gnupg software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial gnupg && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/22.04/Dockerfile
@@ -103,8 +103,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Server/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/24.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.54.0-0ppa1~ubuntu24.04.1'
 ARG jdkServerLinuxComponent='https://corretto.aws/downloads/resources/21.0.10.7.1/amazon-corretto-21.0.10.7.1-linux-x64.tar.gz'
 ARG jdkServerLinuxComponentMD5SUM='7bf7339989b58c74fedbd58e26bb03ec'
 ARG p4Version='r25.2'
-ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG ubuntuImage='ubuntu:24.04'
 
 # The list of required arguments
@@ -100,10 +99,17 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
      # Mercurial
-    apt-get install -y mercurial gnupg software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial gnupg && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Server/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/24.04/Dockerfile
@@ -100,15 +100,15 @@ ARG gitLinuxComponentVersion
 RUN apt-get update && \
      # Mercurial
     apt-get install -y mercurial gnupg && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Server/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/24.04/Dockerfile
@@ -102,13 +102,13 @@ RUN apt-get update && \
     apt-get install -y mercurial gnupg && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26x86_64/p4" && \

--- a/context/generated/linux/Server/Ubuntu/24.04/Dockerfile
+++ b/context/generated/linux/Server/Ubuntu/24.04/Dockerfile
@@ -103,8 +103,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -100,15 +100,15 @@ ARG gitLinuxComponentVersion
 RUN apt-get update && \
     # Mercurial
     apt-get install -y mercurial gnupg && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -102,13 +102,13 @@ RUN apt-get update && \
     apt-get install -y mercurial gnupg && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.41.0-0ppa1~ubuntu18.04.1'
 ARG jdkServerLinuxARM64Component='https://corretto.aws/downloads/resources/21.0.10.7.1/amazon-corretto-21.0.10.7.1-linux-aarch64.tar.gz'
 ARG jdkServerLinuxARM64ComponentMD5SUM='c6952584f21e2473609a6012bd38354f'
 ARG p4Version='r25.2'
-ARG repo=''
 ARG ubuntuImage='ubuntu:18.04'
 
 # The list of required arguments
@@ -48,8 +47,7 @@ FROM ${ubuntuImage}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip \
+
     # See: TW-91621
     netcat-openbsd \
     # Git & Git LFS Runtime dependencies
@@ -101,10 +99,17 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
     # Mercurial
-    apt-get install -y mercurial gnupg software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial gnupg && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/18.04/Dockerfile
@@ -103,8 +103,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -100,15 +100,15 @@ ARG gitLinuxComponentVersion
 RUN apt-get update && \
     # Mercurial
     apt-get install -y mercurial gnupg && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -102,13 +102,13 @@ RUN apt-get update && \
     apt-get install -y mercurial gnupg && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.54.0-0ppa1~ubuntu24.04.1'
 ARG jdkServerLinuxARM64Component='https://corretto.aws/downloads/resources/21.0.10.7.1/amazon-corretto-21.0.10.7.1-linux-aarch64.tar.gz'
 ARG jdkServerLinuxARM64ComponentMD5SUM='c6952584f21e2473609a6012bd38354f'
 ARG p4Version='r25.2'
-ARG repo=''
 ARG ubuntuImage='ubuntu:20.04'
 
 # The list of required arguments
@@ -48,8 +47,7 @@ FROM ${ubuntuImage}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip \
+
     # See: TW-91621
     netcat-openbsd \
     # Git & Git LFS Runtime dependencies
@@ -101,10 +99,17 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
     # Mercurial
-    apt-get install -y mercurial gnupg software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial gnupg && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/20.04/Dockerfile
@@ -103,8 +103,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -100,15 +100,15 @@ ARG gitLinuxComponentVersion
 RUN apt-get update && \
     # Mercurial
     apt-get install -y mercurial gnupg && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -102,13 +102,13 @@ RUN apt-get update && \
     apt-get install -y mercurial gnupg && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -103,8 +103,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \

--- a/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/22.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.54.0-0ppa1~ubuntu24.04.1'
 ARG jdkServerLinuxARM64Component='https://corretto.aws/downloads/resources/21.0.10.7.1/amazon-corretto-21.0.10.7.1-linux-aarch64.tar.gz'
 ARG jdkServerLinuxARM64ComponentMD5SUM='c6952584f21e2473609a6012bd38354f'
 ARG p4Version='r25.2'
-ARG repo=''
 ARG ubuntuImage='ubuntu:22.04'
 
 # The list of required arguments
@@ -48,8 +47,7 @@ FROM ${ubuntuImage}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip \
+
     # See: TW-91621
     netcat-openbsd \
     # Git & Git LFS Runtime dependencies
@@ -101,10 +99,17 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
     # Mercurial
-    apt-get install -y mercurial gnupg software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial gnupg && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Server/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/24.04/Dockerfile
@@ -100,15 +100,15 @@ ARG gitLinuxComponentVersion
 RUN apt-get update && \
     # Mercurial
     apt-get install -y mercurial gnupg && \
-    # Git - build from GitHub to avoid PPA issues
-    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
-    cd /tmp/git-src && \
-    ./configure --prefix=/usr && \
-    make && \
+    # Git - build from source to avoid PPA issues
+    apt-get install -y --no-install-recommends libssl-dev build-essential autoconf make gcc libcurl4-openssl-dev libexpat1-dev gettext unzip zlib1g-dev curl && \
+    curl -L https://www.kernel.org/pub/software/scm/git/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    make configure && ./configure --prefix=/usr && \
+    make all && \
     make install && \
-    cd / && rm -rf /tmp/git-* && \
+    cd /tmp && rm -rf git-2.54.0* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \

--- a/context/generated/linux/Server/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/24.04/Dockerfile
@@ -102,13 +102,13 @@ RUN apt-get update && \
     apt-get install -y mercurial gnupg && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
-    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
     cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-2.54.0 && \
+    cd git-v2.54.0 && \
     ./configure --prefix=/usr && \
     make && \
     make install && \
-    cd / && rm -rf /tmp/git-2.54.0* && \
+    cd / && rm -rf /tmp/git-* && \
     git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \

--- a/context/generated/linux/Server/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/24.04/Dockerfile
@@ -4,7 +4,6 @@ ARG gitLinuxComponentVersion='1:2.54.0-0ppa1~ubuntu24.04.1'
 ARG jdkServerLinuxARM64Component='https://corretto.aws/downloads/resources/21.0.10.7.1/amazon-corretto-21.0.10.7.1-linux-aarch64.tar.gz'
 ARG jdkServerLinuxARM64ComponentMD5SUM='c6952584f21e2473609a6012bd38354f'
 ARG p4Version='r25.2'
-ARG repo=''
 ARG ubuntuImage='ubuntu:24.04'
 
 # The list of required arguments
@@ -48,8 +47,7 @@ FROM ${ubuntuImage}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates fontconfig locales unzip \
+
     # See: TW-91621
     netcat-openbsd \
     # Git & Git LFS Runtime dependencies
@@ -101,10 +99,17 @@ ARG gitLinuxComponentVersion
 
 RUN apt-get update && \
     # Mercurial
-    apt-get install -y mercurial gnupg software-properties-common && \
-    # Git
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt-get install -y git=${gitLinuxComponentVersion} && \
+    apt-get install -y mercurial gnupg && \
+    # Git - build from GitHub to avoid PPA issues
+    apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
+    curl -L https://github.com/git/git/releases/download/v2.54.0/git-2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
+    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
+    cd git-2.54.0 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd / && rm -rf /tmp/git-2.54.0* && \
+    git --version && \
     # Perforce (p4 CLI)
     curl -Lo /usr/local/bin/p4 "https://www.perforce.com/downloads/perforce/${p4Version}/bin.linux26aarch64/p4" && \
     chmod +x /usr/local/bin/p4 && \

--- a/context/generated/linux/Server/UbuntuARM/24.04/Dockerfile
+++ b/context/generated/linux/Server/UbuntuARM/24.04/Dockerfile
@@ -103,8 +103,8 @@ RUN apt-get update && \
     # Git - build from GitHub to avoid PPA issues
     apt-get install -y --no-install-recommends make gcc zlib1g-dev openssh-client && \
     curl -L https://github.com/git/git/archive/refs/tags/v2.54.0.tar.gz -o /tmp/git-2.54.0.tar.gz && \
-    cd /tmp && tar -xzf git-2.54.0.tar.gz && \
-    cd git-v2.54.0 && \
+    mkdir -p /tmp/git-src && tar -xzf /tmp/git-2.54.0.tar.gz -C /tmp/git-src --strip-components=1 && \
+    cd /tmp/git-src && \
     ./configure --prefix=/usr && \
     make && \
     make install && \


### PR DESCRIPTION
The pull request changes the way Git is bundled into TeamCity Docker images to work around the temporary unavailability of the Git Core PPA.

```
ERROR: failed to build: add-apt-repository ppa:git-core/ppa -y &&     apt-get install -y git=1:2.54.0-0ppa1~ubuntu24.04.1
… 
lazr.restfulclient.errors.ServerError: HTTP Error 504: Gateway Time-out
```